### PR TITLE
minor cleanup in SM READMEs

### DIFF
--- a/languages/csharp/SecureMemory/README.md
+++ b/languages/csharp/SecureMemory/README.md
@@ -19,6 +19,9 @@ The protected memory implementation of secure memory
 * Uses mprotect to mark the pages no-access until needed
 * If the operating system supports it, uses madvise to disallow core dumps of protected regions
 * If the operating system does not support madvise, uses setrlimit to disable core dumps entirely
+
+## TODO
+* Add unit tests that generate core dumps and scan them for secrets (need to extract gcore source)
 * If the operating system supports it, uses madvise to request that mapped pages be zeroed on exit
 
 ## Usage
@@ -33,24 +36,3 @@ using (Secret secretKey = secretFactory.CreateSecret(secretBytes))
     });
 }
 ```      
-
-
-## Library Development Notes
-
-### Running Tests Locally via Docker Image
-Below is an example of how to run tests locally using a Docker image. This one is using the build image used for Jenkins build/deployment, but could be replaced with other images for different targeted platforms. Note this is run from your project directory.
-
-```console
-[user@machine SecureMemoryCSharp]$ docker build images/build/
-...
-Successfully built <generated_image_id>
-[user@machine SecureMemoryCSharp]$ docker run -it --rm -v $HOME/.nuget:/home/jenkins/.nuget -v "$PWD":/usr/app/src -w /usr/app/src --ulimit memlock=-1:-1 --ulimit core=-1:-1 <generated_image_id> dotnet clean -c Release && dotnet restore && dotnet build -c Release --no-restore && dotnet test -c Release --no-build /p:CollectCoverage=true /p:Exclude=\"[xunit*]*,[*.Tests]*\" /p:CoverletOutputFormat=cobertura /p:ExcludeByFile="../**/MacOS/**/*.cs" && dotnet pack -c Release --no-restore
-...
-```
-*Note*: The above build is known to work on macOS due to how the bind mounts map UIDs. On Linux systems you will likely need to add the optional build arguments:
-
-``` console
-[user@machine SecureMemoryCSharp]$ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) images/build
-```
-
-This will create the container's user with your UID so that it has full access to the .nuget directory.

--- a/languages/java/secure-memory/README.md
+++ b/languages/java/secure-memory/README.md
@@ -26,12 +26,12 @@ The protected memory implementation of secure memory
 * Uses mprotect to mark the pages no-access until needed
 * If the operating system supports it, uses madvise to disallow core dumps of protected regions
 * If the operating system does not support madvise, uses setrlimit to disable core dumps entirely
-* If the operating system supports it, uses madvise to request that mapped pages be zeroed on exit
 
 ## Todo
 
 * Add support for Cleaner rather than finalizer
 * Add unit tests that generate core dumps and scan them for secrets (need to extract gcore source)
+* If the operating system supports it, uses madvise to request that mapped pages be zeroed on exit
 
 ## Usage
 
@@ -44,26 +44,3 @@ try (Secret secretKey = secretFactory.createSecret(getSecretFromStore())) {
   });
 }
 ```
-
-## Library Development Notes
-
-### Running Tests Locally via Docker Image
-Below is an example of how to run tests locally using a Docker image. This one is using the build image used for
-Jenkins build/deployment, but could be replaced with other images for different targeted platforms. Note this is run
-from your project directory.
-
-```console
-[user@machine SecureMemoryJava]$ docker build images/build/
-...
-Successfully built <generated_image_id>
-[user@machine SecureMemoryJava]$ docker run -it --rm -v $HOME/.m2:/home/jenkins/.m2 -v "$PWD":/usr/app/src -w /usr/app/src --ulimit memlock=-1:-1 --ulimit core=-1:-1 <generated_image_id> mvn clean install
-...
-```
-*Note*: The above build is known to work on macOS due to how the bind mounts map UIDs. On Linux systems you will likely
-need to add the optional build arguments:
-
-``` console
-[user@machine SecureMemoryJava]$ docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) images/build
-```
-
-This will create the container's user with your UID so that it has full access to the .m2 directory.


### PR DESCRIPTION
- remove docker build info until we add it back with external cicd effort
- clarified current state of implementation info
- leaving bulk of the info in them as is for now as upcoming golang SM implementation may change how we convey SM info