### PR TITLE
Deadlock bug fix

### DIFF
--- a/languages/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/AdoMetastorePersistenceImplTest.cs
+++ b/languages/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/AdoMetastorePersistenceImplTest.cs
@@ -246,14 +246,14 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Persistence
         }
 
         [Fact]
-        private void TestStoreWithSqlException()
+        private void TestStoreWithSqlExceptionShouldReturnFalse()
         {
             AdoMetastorePersistenceImpl adoMetastorePersistenceImpl = new AdoMetastorePersistenceImpl(
                 dbProviderFactory,
                 fakeDbConnectionStringBuilder.ConnectionString);
             string keyId = KeyStringWithParentKeyMetaKey;
-            Assert.Throws<AppEncryptionException>(() =>
-                adoMetastorePersistenceImpl.Store(keyId, DateTimeOffset.UtcNow, new JObject()));
+            bool actualValue = adoMetastorePersistenceImpl.Store(keyId, DateTimeOffset.UtcNow, new JObject());
+            Assert.False(actualValue);
         }
 
         [Fact]

--- a/languages/csharp/AppEncryption/AppEncryption/Persistence/AdoMetastorePersistenceImpl.cs
+++ b/languages/csharp/AppEncryption/AppEncryption/Persistence/AdoMetastorePersistenceImpl.cs
@@ -23,10 +23,8 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
 
         private const string LoadQuery = @"SELECT key_record from encryption_key where id = @id and created = @created";
 
-        // We try to store even if a value with the same key exists
-        // since dotnet doesn't provide a specific integrity violation exception
         private const string StoreQuery =
-            @"INSERT INTO encryption_key (id, created, key_record) SELECT @id, @created, @key_record";
+            @"INSERT INTO encryption_key (id, created, key_record) VALUES (@id, @created, @key_record)";
 
         private const string LoadLatestQuery =
             @"SELECT key_record from encryption_key where id = @id order by created DESC limit 1";
@@ -129,7 +127,8 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
                 {
                     Logger.LogError(dbe, "Metastore error during store");
 
-                    // Even if the query failed due to a duplicate record return false
+                    // ADO based persistence does not provide any kind of specific integrity violation error
+                    // code/exception. Hence we always return false even for systemic issues to keep things simple.
                     return false;
                 }
             }


### PR DESCRIPTION
The way INSERT query was written using (WHERE NOT EXISTS) caused deadlocks when multiple threads try to write the same value at the same time. 
Fixed by always returning a false if the query fails