### PR TITLE
checkpoint of CircleCI and Codecov infra

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,30 @@
 version: 2.1
+
+orbs:
+  compare-url: iynere/compare-url@1.2.0
+
 jobs:
   build:
     docker:
       - image: circleci/python:3.7
     steps:
       - checkout
-      - run:
-          # Modeled off of https://github.com/Tufin/circleci-monorepo
-          name: Determine which projects have changed and trigger the builds
-          command: |
-            # Identify modified directories
+      - compare-url/reconstruct
+      - compare-url/use:
+          step-name: Determine which projects have changed and trigger the builds
+          custom-logic: |
+            # Some of this is based off https://github.com/Tufin/circleci-monorepo
 
-            LAST_SUCCESSFUL_BUILD_URL="https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH?filter=completed&limit=1"
-            LAST_SUCCESSFUL_COMMIT=`curl -Ss -u "$CIRCLE_TOKEN:" $LAST_SUCCESSFUL_BUILD_URL | jq -r '.[0]["vcs_revision"]'`
+            # Identify modified directories using compare-url ORB
 
-            #first commit in a branch
-            if [[ ${LAST_SUCCESSFUL_COMMIT} == "null" ]]; then
-              COMMITS="origin/master"
-            else
-              COMMITS="${CIRCLE_SHA1}..${LAST_SUCCESSFUL_COMMIT}"
-            fi
-
-            # Results in "languages/<lang>/<project>", "samples/<lang>/<project>", and "tests/<lang>/<project>"
-            git diff --name-only $COMMITS | cut -d/ -f1,2,3 | sort -u > projects
-            echo -e "Modified directories:\n`cat projects`\n"
-
+            # Assumes structure of "languages/<lang>/<project>", "samples/<lang>/<project>", etc.
+            git diff --name-only $COMMIT_RANGE  | cut -d/ -f1,2,3 | sort -u > project_candidates
+            echo -e "Modified directories:\n`cat project_candidates`\n"
 
             # Build affected projects and their dependencies
 
-            projects_inc_dep=(`cat projects`)
-            # TODO Be nice if we can handle dependencies here for chaining builds when needed, but may be complex w/ multiple langauges
+            projects_inc_dep=(`cat project_candidates`)
+            # TODO Bonus if we can handle dependencies here for chaining builds when needed, but may be complex w/ multiple langauges
             #echo -e "Calculating dependencies\n"
             #for dir in `ls -d */`; do
             #  for dep in `go list -f '{{ .Deps }}' ./${dir} 2>/dev/null`; do
@@ -41,7 +36,7 @@ jobs:
             #  done
             #done
 
-            echo -e "Building: ${projects_inc_dep[@]}\n"
+            echo -e "Evaluating whether to build: ${projects_inc_dep[@]}\n"
             for project in ${projects_inc_dep[@]}; do
               if grep -Fxq $project project-dirs; then
                 printf "\nTriggerring build for project: "$project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,115 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          # Modeled off of https://github.com/Tufin/circleci-monorepo
+          name: Determine which projects have changed and trigger the builds
+          command: |
+            # Identify modified directories
+
+            LAST_SUCCESSFUL_BUILD_URL="https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH?filter=completed&limit=1"
+            LAST_SUCCESSFUL_COMMIT=`curl -Ss -u "$CIRCLE_TOKEN:" $LAST_SUCCESSFUL_BUILD_URL | jq -r '.[0]["vcs_revision"]'`
+
+            #first commit in a branch
+            if [[ ${LAST_SUCCESSFUL_COMMIT} == "null" ]]; then
+              COMMITS="origin/master"
+            else
+              COMMITS="${CIRCLE_SHA1}..${LAST_SUCCESSFUL_COMMIT}"
+            fi
+
+            # Results in "languages/<lang>/<project>", "samples/<lang>/<project>", and "tests/<lang>/<project>"
+            git diff --name-only $COMMITS | cut -d/ -f1,2,3 | sort -u > projects
+            echo -e "Modified directories:\n`cat projects`\n"
+
+
+            # Build affected projects and their dependencies
+
+            projects_inc_dep=(`cat projects`)
+            # TODO Be nice if we can handle dependencies here for chaining builds when needed, but may be complex w/ multiple langauges
+            #echo -e "Calculating dependencies\n"
+            #for dir in `ls -d */`; do
+            #  for dep in `go list -f '{{ .Deps }}' ./${dir} 2>/dev/null`; do
+            #    for project_dep in `echo $dep | grep github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME | egrep -v "vendor|${dir%\/}"`; do
+            #      if [[ " ${projects_inc_dep[@]} " =~ " ${project_dep##*\/} " ]] && ! [[ " ${projects_inc_dep[@]} " =~ " ${dir%\/} " ]]; then
+            #        projects_inc_dep+=(${dir%\/})
+            #      fi
+            #    done
+            #  done
+            #done
+
+            echo -e "Building: ${projects_inc_dep[@]}\n"
+            for project in ${projects_inc_dep[@]}; do
+              if grep -Fxq $project project-dirs; then
+                printf "\nTriggerring build for project: "$project
+                project_fixed_up=$(echo $project | tr / -)
+                curl -s -u ${CIRCLE_TOKEN}: \
+                  -d build_parameters[CIRCLE_JOB]=${project_fixed_up} \
+                  https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+              fi
+            done
+  languages-java-secure-memory:
+    working_directory: ~/asherah/languages/java/secure-memory
+    docker:
+      - image: circleci/openjdk:8-jdk
+    #environment:
+    #  TEST_RESULTS: /tmp/test-results
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            # when pom changes, use increasingly general patterns to restore cache.
+            # vN prefix in case we ever need to regenerate all caches
+            - v1-java-secure-memory-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - v1-java-secure-memory-{{ .Branch }}-
+            - v1-java-secure-memory-
+      - run: mvn dependency:resolve-plugins dependency:go-offline
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-java-secure-memory-{{ .Branch }}-{{ checksum "pom.xml" }}
+      - run:
+          name: Build
+          command: |
+            ./scripts/clean.sh
+            ./scripts/build.sh
+      - run:
+          name: Tests
+          command: |
+            ./scripts/test.sh
+      - store_test_results:
+          path: target/surefire-reports
+  languages-java-app-encryption:
+    working_directory: ~/asherah/languages/java/app-encryption
+    docker:
+      - image: circleci/openjdk:8-jdk
+    #environment:
+    #  TEST_RESULTS: /tmp/test-results
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            # when pom changes, use increasingly general patterns to restore cache.
+            # vN prefix in case we ever need to regenerate all caches
+            - v1-java-app-encryption-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - v1-java-app-encryption-{{ .Branch }}-
+            - v1-java-app-encryption-
+      - run: mvn dependency:resolve-plugins dependency:go-offline
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-java-app-encryption-{{ .Branch }}-{{ checksum "pom.xml" }}
+      - run:
+          name: Build
+          command: |
+            ./scripts/clean.sh
+            ./scripts/build.sh
+      - run:
+          name: Tests
+          command: |
+            ./scripts/test.sh
+      - store_test_results:
+          path: target/surefire-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,14 @@ version: 2.1
 
 orbs:
   compare-url: iynere/compare-url@1.2.0
+  codecov: codecov/codecov@1.0.2
 
 workflows:
   version: 2
   build-test-and-maybe-deploy:
     jobs:
       # only if we want conditional build logic (circleci workflow limitations will still lead to some steps running)
+      # update: may be able to use env variables in workflow context and rely on circleci halt step. codecov impact?
       #- build
       - languages-java-secure-memory
       #- languages-java-app-encryption:
@@ -89,6 +91,9 @@ jobs:
           key: v1-maven-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
       - store_test_results:
           path: languages/java/secure-memory/target/surefire-reports
+      - codecov/upload:
+          file: languages/java/secure-memory/target/site/jacoco/jacoco.xml
+          flags: languages-java-secure-memory
   languages-java-app-encryption:
     docker:
       - image: circleci/openjdk:8-jdk
@@ -120,3 +125,6 @@ jobs:
           key: v1-maven-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
       - store_test_results:
           path: languages/java/app-encryption/target/surefire-reports
+      - codecov/upload:
+          file: languages/java/app-encryption/target/site/jacoco/jacoco.xml
+          flags: languages-java-app-encryption

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   compare-url: iynere/compare-url@1.2.0
-  codecov: codecov/codecov@1.0.2
+  codecov: codecov/codecov@1.0.5
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,13 @@ jobs:
               fi
             done
   languages-java-secure-memory:
-    working_directory: ~/asherah/languages/java/secure-memory
     docker:
       - image: circleci/openjdk:8-jdk
     #environment:
     #  TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
+      - run: cd languages/java/secure-memory
       - restore_cache:
           keys:
             # when pom changes, use increasingly general patterns to restore cache.
@@ -90,13 +90,13 @@ jobs:
       - store_test_results:
           path: target/surefire-reports
   languages-java-app-encryption:
-    working_directory: ~/asherah/languages/java/app-encryption
     docker:
       - image: circleci/openjdk:8-jdk
     #environment:
     #  TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
+      - run: cd languages/java/app-encryption
       - restore_cache:
           keys:
             # when pom changes, use increasingly general patterns to restore cache.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
                 project_fixed_up=$(echo $project | tr / -)
                 curl -s -u ${CIRCLE_TOKEN}: \
                   -d build_parameters[CIRCLE_JOB]=${project_fixed_up} \
-                  https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+                  https://circleci.com/api/v2/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
               fi
             done
   languages-java-secure-memory:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,9 @@ workflows:
       # only if we want conditional build logic (circleci workflow limitations will still lead to some steps running)
       #- build
       - languages-java-secure-memory
-      - languages-java-app-encryption:
-          requires:
-            - languages-java-secure-memory
+      #- languages-java-app-encryption:
+      #    requires:
+      #      - languages-java-secure-memory
 
 jobs:
   build:
@@ -69,18 +69,9 @@ jobs:
           keys:
             # when pom changes, use increasingly general patterns to restore cache.
             # vN prefix in case we ever need to regenerate all caches
-            - v1-java-secure-memory-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
-            - v1-java-secure-memory-{{ .Branch }}-
-            - v1-java-secure-memory-
-      - run:
-          name: Download dependencies for cache
-          command: |
-            cd languages/java/secure-memory
-            mvn dependency:resolve-plugins dependency:go-offline
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-java-secure-memory-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
+            - v1-maven-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
+            - v1-maven-{{ .Branch }}-
+            - v1-maven-
       - run:
           name: Build
           command: |
@@ -92,6 +83,10 @@ jobs:
           command: |
             cd languages/java/secure-memory
             ./scripts/test.sh
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-maven-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
       - store_test_results:
           path: languages/java/secure-memory/target/surefire-reports
   languages-java-app-encryption:
@@ -105,18 +100,9 @@ jobs:
           keys:
             # when pom changes, use increasingly general patterns to restore cache.
             # vN prefix in case we ever need to regenerate all caches
-            - v1-java-app-encryption-{{ .Branch }}-{{ checksum "languages/java/app-encryption/pom.xml" }}
-            - v1-java-app-encryption-{{ .Branch }}-
-            - v1-java-app-encryption-
-      - run:
-          name: Download dependencies for cache
-          command: |
-            cd languages/java/app-encryption
-            mvn dependency:resolve-plugins dependency:go-offline
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-java-app-encryption-{{ .Branch }}-{{ checksum "languages/java/app-encryption/pom.xml" }}
+            - v1-maven-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
+            - v1-maven-{{ .Branch }}-
+            - v1-maven-
       - run:
           name: Build
           command: |
@@ -128,5 +114,9 @@ jobs:
           command: |
             cd languages/java/app-encryption
             ./scripts/test.sh
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-maven-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
       - store_test_results:
           path: languages/java/app-encryption/target/surefire-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,18 @@
-version: 2.0
+version: 2.1
 
 orbs:
   compare-url: iynere/compare-url@1.2.0
+
+workflows:
+  version: 2
+  build-test-and-maybe-deploy:
+    jobs:
+      # only if we want conditional build logic (circleci workflow limitations will still lead to some steps running)
+      #- build
+      - languages-java-secure-memory
+      - languages-java-app-encryption:
+          requires:
+            - languages-java-secure-memory
 
 jobs:
   build:
@@ -41,9 +52,10 @@ jobs:
               if grep -Fxq $project project-dirs; then
                 printf "\nTriggerring build for project: "$project
                 project_fixed_up=$(echo $project | tr / -)
-                curl -s -u ${CIRCLE_TOKEN}: \
-                  -d build_parameters[CIRCLE_JOB]=${project_fixed_up} \
-                  https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+                #curl -s -u ${CIRCLE_TOKEN}: \
+                #  -d build_parameters[CIRCLE_JOB]=${project_fixed_up} \
+                #  https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+                touch /tmp/${project_fixed_up}
               fi
             done
   languages-java-secure-memory:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,7 @@ workflows:
   version: 2
   build-test-and-maybe-deploy:
     jobs:
-      # only if we want conditional build logic (circleci workflow limitations will still lead to some steps running)
-      # update: may be able to use env variables in workflow context and rely on circleci halt step. codecov impact?
+      # commenting out for now. add back if/when we want conditional build logic (see TODO in "build" job)
       #- build
       - languages-java-secure-memory
       #- languages-java-app-encryption:
@@ -54,11 +53,8 @@ jobs:
               if grep -Fxq $project project-dirs; then
                 printf "\nTriggerring build for project: "$project
                 project_fixed_up=$(echo $project | tr / -)
-                #curl -s -u ${CIRCLE_TOKEN}: \
-                #  -d build_parameters[CIRCLE_JOB]=${project_fixed_up} \
-                #  https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
 
-                # TODO If we end up following through on this route, need context setup in org and share env vars:
+                # TODO If we end up following through on this route, can use workflow workspace and perist env vars to signal halt:
                 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
                 # https://medium.com/@johnthughes/circleci-persisting-environment-variables-across-steps-and-jobs-5276670cf590
                 # https://discuss.circleci.com/t/ability-to-return-successfully-from-a-job-before-completing-all-the-next-steps/12969/7
@@ -67,8 +63,6 @@ jobs:
   languages-java-secure-memory:
     docker:
       - image: circleci/openjdk:8-jdk
-    #environment:
-    #  TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
       - restore_cache:
@@ -101,8 +95,6 @@ jobs:
   languages-java-app-encryption:
     docker:
       - image: circleci/openjdk:8-jdk
-    #environment:
-    #  TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           path: languages/java/secure-memory/target/surefire-reports
       - codecov/upload:
           file: languages/java/secure-memory/target/site/jacoco/jacoco.xml
-          flags: languages-java-secure-memory
+          flags: languages_java_secure_memory
   languages-java-app-encryption:
     docker:
       - image: circleci/openjdk:8-jdk
@@ -127,4 +127,4 @@ jobs:
           path: languages/java/app-encryption/target/surefire-reports
       - codecov/upload:
           file: languages/java/app-encryption/target/site/jacoco/jacoco.xml
-          flags: languages-java-app-encryption
+          flags: languages_java_app_encryption

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,11 @@ jobs:
                 #curl -s -u ${CIRCLE_TOKEN}: \
                 #  -d build_parameters[CIRCLE_JOB]=${project_fixed_up} \
                 #  https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
-                touch /tmp/${project_fixed_up}
+
+                # TODO If we end up following through on this route, need context setup in org and share env vars:
+                # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
+                # https://medium.com/@johnthughes/circleci-persisting-environment-variables-across-steps-and-jobs-5276670cf590
+                # https://discuss.circleci.com/t/ability-to-return-successfully-from-a-job-before-completing-all-the-next-steps/12969/7
               fi
             done
   languages-java-secure-memory:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,30 +65,35 @@ jobs:
     #  TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
-      - run: cd languages/java/secure-memory
       - restore_cache:
           keys:
             # when pom changes, use increasingly general patterns to restore cache.
             # vN prefix in case we ever need to regenerate all caches
-            - v1-java-secure-memory-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - v1-java-secure-memory-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
             - v1-java-secure-memory-{{ .Branch }}-
             - v1-java-secure-memory-
-      - run: mvn dependency:resolve-plugins dependency:go-offline
+      - run:
+          name: Download dependencies for cache
+          command: |
+            cd languages/java/secure-memory
+            mvn dependency:resolve-plugins dependency:go-offline
       - save_cache:
           paths:
             - ~/.m2
-          key: v1-java-secure-memory-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: v1-java-secure-memory-{{ .Branch }}-{{ checksum "languages/java/secure-memory/pom.xml" }}
       - run:
           name: Build
           command: |
+            cd languages/java/secure-memory
             ./scripts/clean.sh
             ./scripts/build.sh
       - run:
           name: Tests
           command: |
+            cd languages/java/secure-memory
             ./scripts/test.sh
       - store_test_results:
-          path: target/surefire-reports
+          path: languages/java/secure-memory/target/surefire-reports
   languages-java-app-encryption:
     docker:
       - image: circleci/openjdk:8-jdk
@@ -96,27 +101,32 @@ jobs:
     #  TEST_RESULTS: /tmp/test-results
     steps:
       - checkout
-      - run: cd languages/java/app-encryption
       - restore_cache:
           keys:
             # when pom changes, use increasingly general patterns to restore cache.
             # vN prefix in case we ever need to regenerate all caches
-            - v1-java-app-encryption-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - v1-java-app-encryption-{{ .Branch }}-{{ checksum "languages/java/app-encryption/pom.xml" }}
             - v1-java-app-encryption-{{ .Branch }}-
             - v1-java-app-encryption-
-      - run: mvn dependency:resolve-plugins dependency:go-offline
+      - run:
+          name: Download dependencies for cache
+          command: |
+            cd languages/java/app-encryption
+            mvn dependency:resolve-plugins dependency:go-offline
       - save_cache:
           paths:
             - ~/.m2
-          key: v1-java-app-encryption-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: v1-java-app-encryption-{{ .Branch }}-{{ checksum "languages/java/app-encryption/pom.xml" }}
       - run:
           name: Build
           command: |
+            cd languages/java/app-encryption
             ./scripts/clean.sh
             ./scripts/build.sh
       - run:
           name: Tests
           command: |
+            cd languages/java/app-encryption
             ./scripts/test.sh
       - store_test_results:
-          path: target/surefire-reports
+          path: languages/java/app-encryption/target/surefire-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.0
 
 orbs:
   compare-url: iynere/compare-url@1.2.0
@@ -43,7 +43,7 @@ jobs:
                 project_fixed_up=$(echo $project | tr / -)
                 curl -s -u ${CIRCLE_TOKEN}: \
                   -d build_parameters[CIRCLE_JOB]=${project_fixed_up} \
-                  https://circleci.com/api/v2/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+                  https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
               fi
             done
   languages-java-secure-memory:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,8 +17,8 @@ coverage:
         flags: languages_java_app_encryption
         target: 90%
       languages-java-secure-memory:
-        target: 90%
         flags: languages_java_secure_memory
+        target: 90%
 # Note flags have to be "\w" charset (hence underscore instead of hyphen)
 flags:
   languages_csharp_AppEncryption:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -39,4 +39,4 @@ flags:
 ignore:
   # Ignore non-linux native paths. Ideally, be nice to setup separate OS-specific builds.
   # No need for C# path since the dotnet test command handles it currently (should change if/when we do the above)
-  - languages/java/secure-memory/src/main/com/godaddy/securememory/protectedmemoryimpl/macos
+  - languages/java/secure-memory/src/main/java/com/godaddy/securememory/protectedmemoryimpl/macos

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -39,4 +39,4 @@ flags:
 ignore:
   # Ignore non-linux native paths. Ideally, be nice to setup separate OS-specific builds.
   # No need for C# path since the dotnet test command handles it currently (should change if/when we do the above)
-  - languages/java/secure-memory/src/main/com/godaddy/securememory/protectedmemoryimpl/macos/*
+  - languages/java/secure-memory/src/main/com/godaddy/securememory/protectedmemoryimpl/macos

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -39,4 +39,4 @@ flags:
 ignore:
   # Ignore non-linux native paths. Ideally, be nice to setup separate OS-specific builds.
   # No need for C# path since the dotnet test command handles it currently (should change if/when we do the above)
-  - languages/java/secure-memory/src/main/java/com/godaddy/securememory/protectedmemoryimpl/macos
+  - "**/com/godaddy/asherah/securememory/protectedmemoryimpl/macos" # java macos path

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,34 +5,35 @@ coverage:
         target: 90%
         threshold: 5%
       #languages-csharp-AppEncryption:
-      #  flags: languages-csharp-AppEncryption
+      #  flags: languages_csharp_AppEncryption
       #  target: 90%
       #languages-csharp-Logging:
-      #  flags: languages-csharp-Logging
+      #  flags: languages_csharp_Logging
       #  target: 90%
       #languages-csharp-SecureMemory:
-      #  flags: languages-csharp-SecureMemory
+      #  flags: languages_csharp_SecureMemory
       #  target: 90%
       languages-java-app-encryption:
-        flags: languages-java-app-encryption
+        flags: languages_java_app_encryption
         target: 90%
       languages-java-secure-memory:
         target: 90%
-        flags: languages-java-secure-memory
+        flags: languages_java_secure_memory
+# Note flags have to be "\w" charset (hence underscore instead of hyphen)
 flags:
-  languages-csharp-AppEncryption:
+  languages_csharp_AppEncryption:
     paths:
       - languages/csharp/AppEncryption
-  languages-csharp-Logging:
+  languages_csharp_Logging:
     paths:
       - languages/csharp/Logging
-  languages-csharp-SecureMemory:
+  languages_csharp_SecureMemory:
     paths:
       - languages/csharp/SecureMemory
-  languages-java-app-encryption:
+  languages_java_app_encryption:
     paths:
       - languages/java/app-encryption
-  languages-java-secure-memory:
+  languages_java_secure_memory:
     paths:
       - languages/java/secure-memory
 ignore:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,41 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 5%
+      #languages-csharp-AppEncryption:
+      #  flags: languages-csharp-AppEncryption
+      #  target: 90%
+      #languages-csharp-Logging:
+      #  flags: languages-csharp-Logging
+      #  target: 90%
+      #languages-csharp-SecureMemory:
+      #  flags: languages-csharp-SecureMemory
+      #  target: 90%
+      languages-java-app-encryption:
+        flags: languages-java-app-encryption
+        target: 90%
+      languages-java-secure-memory:
+        target: 90%
+        flags: languages-java-secure-memory
+flags:
+  languages-csharp-AppEncryption:
+    paths:
+      - languages/csharp/AppEncryption
+  languages-csharp-Logging:
+    paths:
+      - languages/csharp/Logging
+  languages-csharp-SecureMemory:
+    paths:
+      - languages/csharp/SecureMemory
+  languages-java-app-encryption:
+    paths:
+      - languages/java/app-encryption
+  languages-java-secure-memory:
+    paths:
+      - languages/java/secure-memory
+ignore:
+  # Ignore non-linux native paths. Ideally, be nice to setup separate OS-specific builds.
+  # No need for C# path since the dotnet test command handles it currently (should change if/when we do the above)
+  - languages/java/secure-memory/src/main/com/godaddy/securememory/protectedmemoryimpl/macos/*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join Slack](https://img.shields.io/badge/Join%20us%20on-Slack-e01563.svg)](https://godaddy-oss-slack.herokuapp.com/)
 [![License](https://img.shields.io/github/license/godaddy/asherah.svg)](https://github.com/godaddy/asherah/blob/master/LICENSE)
 [![CircleCI](https://img.shields.io/circleci/build/gh/godaddy/asherah.svg)](https://circleci.com/gh/godaddy/asherah)
-[![Codecov](https://img.shields.io/codecov/c/gh/godaddy/asherah.svg)](https://codecov.io/gh/godaddy/asherah)
+[![Codecov](https://codecov.io/gh/godaddy/asherah.svg)](https://codecov.io/gh/godaddy/asherah)
 
 Asherah is an application-layer encryption SDK, currently in incubator status, that provides advanced encryption
 features and defense in depth against compromise.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Join Slack](https://img.shields.io/badge/Join%20us%20on-Slack-e01563.svg)](https://godaddy-oss-slack.herokuapp.com/)
 [![License](https://img.shields.io/github/license/godaddy/asherah.svg)](https://github.com/godaddy/asherah/blob/master/LICENSE)
+[![CircleCI](https://img.shields.io/circleci/build/gh/godaddy/asherah.svg)](https://circleci.com/gh/godaddy/asherah)
+[![Codecov](https://img.shields.io/codecov/c/gh/godaddy/asherah.svg)](https://codecov.io/gh/godaddy/asherah)
 
 Asherah is an application-layer encryption SDK, currently in incubator status, that provides advanced encryption
 features and defense in depth against compromise.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join Slack](https://img.shields.io/badge/Join%20us%20on-Slack-e01563.svg)](https://godaddy-oss-slack.herokuapp.com/)
 [![License](https://img.shields.io/github/license/godaddy/asherah.svg)](https://github.com/godaddy/asherah/blob/master/LICENSE)
 [![CircleCI](https://img.shields.io/circleci/build/gh/godaddy/asherah.svg)](https://circleci.com/gh/godaddy/asherah)
-[![Codecov](https://codecov.io/gh/godaddy/asherah.svg)](https://codecov.io/gh/godaddy/asherah)
+[![Codecov](https://codecov.io/gh/godaddy/asherah/graph/badge.svg)](https://codecov.io/gh/godaddy/asherah)
 
 Asherah is an application-layer encryption SDK, currently in incubator status, that provides advanced encryption
 features and defense in depth against compromise.

--- a/languages/java/secure-memory/README.md
+++ b/languages/java/secure-memory/README.md
@@ -4,6 +4,7 @@ This class provides a way for applications to keep secret information (like cryp
 that is secure in the described ways.
 
 ## Currently supported / tested platforms
+
 * MacOS x86-64
 * Linux x86-64
 

--- a/languages/java/secure-memory/README.md
+++ b/languages/java/secure-memory/README.md
@@ -21,6 +21,7 @@ Any implementation must have the following guarantees in so far as secret inform
 * Values stored will be securely / explicitly zeroed out when no longer in use
 
 ## Protected Memory Implementation
+
 The protected memory implementation of secure memory
 
 * Uses mlock to lock the pages to prevent swapping

--- a/languages/java/secure-memory/README.md
+++ b/languages/java/secure-memory/README.md
@@ -25,7 +25,6 @@ Any implementation must have the following guarantees in so far as secret inform
 ## Protected Memory Implementation
 
 The protected memory implementation of secure memory
-
 * Uses mlock to lock the pages to prevent swapping
 * Uses mprotect to mark the pages no-access until needed
 * If the operating system supports it, uses madvise to disallow core dumps of protected regions

--- a/languages/java/secure-memory/README.md
+++ b/languages/java/secure-memory/README.md
@@ -15,6 +15,7 @@ that is secure in the described ways.
 * Minimize the lifetime of secrets in managed memory
 
 ## Guarantees
+
 Any implementation must have the following guarantees in so far as secret information stored in secure memory
 
 * Values stored will not show up in core dumps

--- a/languages/java/secure-memory/README.md
+++ b/languages/java/secure-memory/README.md
@@ -1,4 +1,5 @@
 # SecureMemory Java Edition
+
 This class provides a way for applications to keep secret information (like cryptographic keys) in an area of memory
 that is secure in the described ways.
 

--- a/project-dirs
+++ b/project-dirs
@@ -1,0 +1,8 @@
+languages/csharp/AppEncryption
+languages/csharp/Logging
+languages/csharp/SecureMemory
+languages/java/app-encryption
+languages/java/secure-memory
+samples/csharp/ReferenceApp
+samples/java/reference-app
+tests/java/test-app


### PR DESCRIPTION
Fixes #79 and #81 

- includes initial structure/templates for CircleCI and Codecov integration
- there is a leftover/incomplete job that can allow us to only build affected parts of the monorepo -- will come back to that later. there are some misc notes around that in the configs
- note this only handles CI currently. CD will be done separately
- added CircleCI and Codecov badges (codecov will be more accurate once all projects have CI hooks)
- some misc whitespace changes in secure memory readme that can be ignored (they were done to trigger builds in earlier versions of the circleci implementation)