### PR TITLE
move native libs needed for tests to build dir

### DIFF
--- a/languages/java/app-encryption/pom.xml
+++ b/languages/java/app-encryption/pom.xml
@@ -161,7 +161,7 @@
             <configuration>
               <includeScope>test</includeScope>
               <includeTypes>so,dll,dylib</includeTypes>
-              <outputDirectory>${project.basedir}/native-libs</outputDirectory>
+              <outputDirectory>${project.build.directory}/native-libs</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/languages/java/app-encryption/src/test/java/com/godaddy/asherah/appencryption/persistence/DynamoDbMetastorePersistenceImplTest.java
+++ b/languages/java/app-encryption/src/test/java/com/godaddy/asherah/appencryption/persistence/DynamoDbMetastorePersistenceImplTest.java
@@ -55,7 +55,7 @@ class DynamoDbMetastorePersistenceImplTest {
 
   @BeforeAll
   public static void setupClass() throws Exception {
-    System.setProperty("sqlite4java.library.path", "native-libs");
+    System.setProperty("sqlite4java.library.path", "target/native-libs");
     String port = DYNAMO_DB_PORT;
     server = ServerRunner.createServerFromCommandLineArgs(
         new String[]{"-inMemory", "-port", port});


### PR DESCRIPTION
- keeps project root clean and avoids having to update gitignore