### PR TITLE
Create packages directory in setup csharp environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
             apt-get update
             apt-get install -y libxml2-utils
             dotnet tool install -g trx2junit
-            mkdir -p ~/.nuget/NuGet/
+            mkdir -p ~/.nuget/{NuGet,packages}
             cp build/NuGet.Config ~/.nuget/NuGet/
       - run:
           name: Build
@@ -286,7 +286,7 @@ jobs:
             apt-get update
             apt-get install -y libxml2-utils
             dotnet tool install -g trx2junit
-            mkdir -p ~/.nuget/NuGet/
+            mkdir -p ~/.nuget/{NuGet,packages}
             cp build/NuGet.Config ~/.nuget/NuGet/
       - run:
           name: Build
@@ -355,7 +355,7 @@ jobs:
             apt-get update
             apt-get install -y libxml2-utils
             dotnet tool install -g trx2junit
-            mkdir -p ~/.nuget/NuGet/
+            mkdir -p ~/.nuget/{NuGet,packages}
             cp build/NuGet.Config ~/.nuget/NuGet/
       - run:
           name: Build
@@ -424,7 +424,7 @@ jobs:
             apt-get update
             apt-get install -y libxml2-utils
             dotnet tool install -g trx2junit
-            mkdir -p ~/.nuget/NuGet/
+            mkdir -p ~/.nuget/{NuGet,packages}
             cp build/NuGet.Config ~/.nuget/NuGet/
       - run:
           name: Build


### PR DESCRIPTION
NuGet does not check for all the sub-directories and would fail if we try to do a `dotnet restore` command.