### PR TITLE
Static kms key

### DIFF
--- a/samples/csharp/ReferenceApp/ReferenceApp/ReferenceApp.cs
+++ b/samples/csharp/ReferenceApp/ReferenceApp/ReferenceApp.cs
@@ -114,7 +114,7 @@ namespace GoDaddy.Asherah.ReferenceApp
             else
             {
                 logger.LogInformation("using static KMS...");
-                keyManagementService = new StaticKeyManagementServiceImpl("secretmasterkey!");
+                keyManagementService = new StaticKeyManagementServiceImpl("mysupersecretstaticmasterkey!!!!");
             }
 
             CryptoPolicy cryptoPolicy = BasicExpiringCryptoPolicy

--- a/samples/java/reference-app/src/main/java/com/godaddy/asherah/referenceapp/App.java
+++ b/samples/java/reference-app/src/main/java/com/godaddy/asherah/referenceapp/App.java
@@ -134,7 +134,7 @@ public final class App implements Callable<Void> {
     else {
       logger.info("using static KMS...");
 
-      keyManagementService = new StaticKeyManagementServiceImpl("secretmasterkey!");
+      keyManagementService = new StaticKeyManagementServiceImpl("mysupersecretstaticmasterkey!!!!");
     }
 
     CryptoPolicy cryptoPolicy = BasicExpiringCryptoPolicy


### PR DESCRIPTION
Use 32 bytes static master key to keep it consistent with future implementations of `Go`