### PR TITLE
fixed option check for region map

### DIFF
--- a/server/go/main.go
+++ b/server/go/main.go
@@ -86,7 +86,7 @@ func validateOptions(opts *Options) error {
 			return errors.New("--preferred-region is required when --kms=aws")
 		}
 
-		if len(opts.Asherah.PreferredRegion) == 0 {
+		if len(opts.Asherah.RegionMap) == 0 {
 			return errors.New("--region-map is required when --kms=aws")
 		}
 	}


### PR DESCRIPTION
The sidecar app is incorrectly checking for `PreferredRegion` twice instead of also checking for `RegionMap` when validating options.