### PR TITLE
added flag to chmod g+rwx socket for non-root access

### DIFF
--- a/server/go/main.go
+++ b/server/go/main.go
@@ -20,8 +20,9 @@ import (
 )
 
 type Options struct {
-	SocketFile flags.Filename  `short:"s" long:"socket-file" default:"/tmp/appencryption.sock" description:"The unix domain socket the server will listen on"`
-	Asherah    *server.Options `group:"Asherah Options"`
+	SocketFile       flags.Filename  `short:"s" long:"socket-file" default:"/tmp/appencryption.sock" description:"The unix domain socket the server will listen on"`
+	SocketAllowGroup bool            `short:"g" long:"allow-group" description:"Allow group read and write to the unix domain socket"`
+	Asherah          *server.Options `group:"Asherah Options"`
 }
 
 func main() {
@@ -52,6 +53,12 @@ func main() {
 		panic(err)
 	}
 	defer l.Close()
+
+	if opts.SocketAllowGroup {
+		if err := os.Chmod(string(opts.SocketFile), 0770); err != nil {
+			panic(err)
+		}
+	}
 
 	service := server.NewAppEncryption(opts.Asherah)
 	grpcServer := grpc.NewServer()


### PR DESCRIPTION
When using Asherah as a sidecar, the default umask of 022 results in a gRPC socket with 755 permissions owned by root. Applications using the sidecar with a shared volume end up requiring root permissions to fully utilize the service. This patch adds an optional flag for changing the permissions on the socket file to allow group access.

By itself, this patch does very little - it does not change ownership of the socket file in any way, just the permissions. It is left to the integrator to ensure the socket is mounted in a way that assigns the correct group membership to files within that path.

## Example

In Docker, we have a shared volume specifically for the Asherah socket:

```bash
docker volume create asherah_socket
```

A non-root application creates the location for the socket, `/sock`, in its `Dockerfile` and forces new files created within to be have the correct group ownership by default:

```
FROM mysrcimg
# ... other stuff
# create Asherah socket mount point
RUN mkdir /sock \
    && chown appuser:appuser /sock \
    && chmod g+sw /sock
USER appuser
ENTRYPOINT ["/mycustomapp"]
```

The application is then started with the shared volume:

```bash
docker run -d --rm \
    -v asherah_socket:/sock \
    mycustomapp
```

Since the custom application is running as a non-root user, starting Asherah without the flag results in a socket with `0755` permissions owned by root, causing errors when the application attempts to write to it:

```bash
docker run -d --rm \
    -v asherah_socket:/sock \
    asherah_sidecar --socket-file /sock/asherah.sock
```

When Asherah is started using the new flag `-g`, the permissions are changed to `0770` and now the application can write to the socket:

```bash
docker run -d --rm \
    -v asherah_socket:/sock \
    asherah_sidecar --socket-file /sock/asherah.sock -g
```

If desired, the patch can be updated to either replace the `other` permission bits (setting to `0775`) or to always chmod the the socket file and explicitly set to `0700` (since the socket is useless without write access).