### PR TITLE
[go/referenceapp] new flags, bump AE to v0.1.1

### DIFF
--- a/samples/go/referenceapp/go.mod
+++ b/samples/go/referenceapp/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.29.26
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/godaddy/asherah/go/appencryption v0.1.0
+	github.com/godaddy/asherah/go/appencryption v0.1.1
 	github.com/google/logger v1.0.1
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/pkg/errors v0.9.1

--- a/samples/go/referenceapp/go.sum
+++ b/samples/go/referenceapp/go.sum
@@ -29,6 +29,8 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/godaddy/asherah/go/appencryption v0.1.0 h1:BVuffWu4x6vg3z49XVmo8cZCI0EgsmVZ8m5uFSFk9Bs=
 github.com/godaddy/asherah/go/appencryption v0.1.0/go.mod h1:Sdf/zejO1+FIYnv7OatryRBrVSzaDBpVTvX5vNeLb0E=
+github.com/godaddy/asherah/go/appencryption v0.1.1 h1:6DNZrgpVeaY5vzsh426K+tm43h2mtbDLYfS67YB5rLA=
+github.com/godaddy/asherah/go/appencryption v0.1.1/go.mod h1:Sdf/zejO1+FIYnv7OatryRBrVSzaDBpVTvX5vNeLb0E=
 github.com/godaddy/asherah/go/securememory v0.1.0 h1:zyJa/rWuc9K6YZdwgbdtk7I6BTshiJDfIQwQkIbxvyk=
 github.com/godaddy/asherah/go/securememory v0.1.0/go.mod h1:N0mgZcRmF/RFjLQBac/LW2EgkBw4BOKHkIT8rO1pBRU=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=

--- a/samples/go/referenceapp/main.go
+++ b/samples/go/referenceapp/main.go
@@ -26,13 +26,15 @@ var (
 )
 
 type Options struct {
-	Drr              string `short:"d" long:"drr-to-decrypt" description:"DRR to be decrypted"`
-	Payload          string `short:"p" long:"payload-to-encrypt" description:"payload to be encrypted"`
-	Metastore        string `short:"m" long:"metastore" description:"Configure what metastore to use (DYNAMODB/SQL/MEMORY)"`
-	ConnectionString string `short:"c" long:"conn" description:"MySQL connection String"`
-	KmsType          string `long:"kms-type" description:"Type of key management service to use (AWS/STATIC)"`
-	PreferredRegion  string `long:"preferred-region" description:"Preferred region to use for KMS if using AWS KMS. Required for AWS KMS."`
-	RegionTuples     string `long:"region-arn-tuples" description:"Comma separated list of <region>=<kms_arn> tuples. Required for AWS KMS."`
+	Drr                string `short:"d" long:"drr-to-decrypt" description:"DRR to be decrypted"`
+	Payload            string `short:"p" long:"payload-to-encrypt" description:"payload to be encrypted"`
+	Metastore          string `short:"m" long:"metastore" description:"Configure what metastore to use (DYNAMODB/SQL/MEMORY)"`
+	EnableRegionSuffix bool   `short:"x" long:"enable-region-suffix" description:"Configure the metastore to use regional suffixes (only supported by DYNAMODB)"`
+	ConnectionString   string `short:"c" long:"conn" description:"MySQL connection String"`
+	KmsType            string `long:"kms-type" description:"Type of key management service to use (AWS/STATIC)"`
+	PreferredRegion    string `long:"preferred-region" description:"Preferred region to use for KMS if using AWS KMS. Required for AWS KMS."`
+	RegionTuples       string `long:"region-arn-tuples" description:"Comma separated list of <region>=<kms_arn> tuples. Required for AWS KMS."`
+	PartitionID        string `long:"partition-id" description:"The partition id to use for client sessions"`
 }
 
 // connectSQL connects to the mysql instance with the provided connection string.
@@ -73,6 +75,7 @@ func createMetastore() appencryption.Metastore {
 
 		sess, e := session.NewSession(&aws.Config{
 			Region: aws.String("us-west-2"),
+			//LogLevel: aws.LogLevel(aws.LogDebug),
 			//Uncomment to use local dynamodb
 			//Endpoint: aws.String("http://localhost:8000"),
 		})
@@ -81,7 +84,7 @@ func createMetastore() appencryption.Metastore {
 			panic(e)
 		}
 
-		return persistence.NewDynamoDBMetastore(sess)
+		return persistence.NewDynamoDBMetastore(sess, persistence.WithDynamoDBRegionSuffix(opts.EnableRegionSuffix))
 	default:
 		logger.Info("using in-memory metastore")
 		return persistence.NewMemoryMetastore()
@@ -152,7 +155,13 @@ func main() {
 
 	// Now create an actual session for a partition (which in our case is a pretend shopper id). This session is used
 	// for a transaction and needs to be closed after use.
-	sess, err := factory.GetSession("shopper123")
+
+	partitionID := opts.PartitionID
+	if partitionID == "" {
+		partitionID = "shopper123"
+	}
+
+	sess, err := factory.GetSession(partitionID)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- upgraded appencryption to v0.1.1
- New flags:
    - `--enable-region-suffix` flag wraps the new AE `WithDynamoDBRegionSuffix` option
    - `--parition-id` flag allows override of default value