### PR TITLE
Fix C# Logging Release

### DIFF
--- a/csharp/Logging/Directory.Build.props
+++ b/csharp/Logging/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Add appropriate repo and license info to the C#  logging release
- Update version as per [note](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/publish-nuget-package)