### PR TITLE
Updated C# metastore exception handling

### DIFF
--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/DynamoDbMetastoreImplTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/DynamoDbMetastoreImplTest.cs
@@ -106,12 +106,10 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Persistence
         }
 
         [Fact]
-        private void TestLoadWithFailureShouldReturnEmpty()
+        private void TestLoadWithFailureShouldThrowException()
         {
             Dispose();
-            Option<JObject> actualJsonObject = dynamoDbMetastoreImpl.Load(TestKey, created);
-
-            Assert.False(actualJsonObject.IsSome);
+            Assert.Throws<Exception>(() => dynamoDbMetastoreImpl.Load(TestKey, created));
         }
 
         [Fact]
@@ -191,12 +189,10 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Persistence
         }
 
         [Fact]
-        private void TestLoadLatestWithFailureShouldReturnEmpty()
+        private void TestLoadLatestWithFailureShouldThrowException()
         {
             Dispose();
-            Option<JObject> actualJsonObject = dynamoDbMetastoreImpl.LoadLatest(TestKey);
-
-            Assert.False(actualJsonObject.IsSome);
+            Assert.Throws<Exception>(() => dynamoDbMetastoreImpl.LoadLatest(TestKey));
         }
 
         [Fact]

--- a/csharp/AppEncryption/Directory.Build.props
+++ b/csharp/AppEncryption/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change modifies the existing C# `IMetastore` implementations so that exceptions that get raised by the database
driver are not suppressed and logged, but instead, bubble up to the caller. The reason for this change is two-fold:

1. Remove unnecessary logging deep in the call stack: by removing the `try`/`catch` blocks in the metastore
implementations, it removes the need for logging at the bottom of the stack, which will make future changes to remove
the existing logging implementation simpler.

2. It preserves the stack trace/exception so that the low-level exception can get added as the `InnerException` property
value of the exception that eventually gets returned by the library. This will make it easier for developers to diagnose
problems with their metastore configurations, since they will now only see a single exception in their logging with a
clear cause and effect between the low-level exception and the exception that gets thrown by the library.