### PR TITLE
[C#] bump AppEncryption to v0.1.2

### DIFF
--- a/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
+++ b/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />
     <PackageReference Include="App.Metrics" Version="3.2.0" />
+    <PackageReference Include="GoDaddy.Asherah.Logging" Version="0.1.1" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="../Crypto/Crypto.csproj" />

--- a/csharp/AppEncryption/Crypto/Crypto.csproj
+++ b/csharp/AppEncryption/Crypto/Crypto.csproj
@@ -14,7 +14,8 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.5" />
-    <PackageReference Include="GoDaddy.Asherah.SecureMemory" Version="0.1.1" />
+    <PackageReference Include="GoDaddy.Asherah.Logging" Version="0.1.1" />
+    <PackageReference Include="GoDaddy.Asherah.SecureMemory" Version="0.1.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
 </Project>

--- a/csharp/AppEncryption/Directory.Build.props
+++ b/csharp/AppEncryption/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- update SecureMemory dependency to v0.1.2
- add Logging dependency (temporary)