### PR TITLE
[Java] Update Guava version to address GitHub security alert

### DIFF
--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.godaddy.asherah</groupId>
   <artifactId>appencryption</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <name>Asherah</name>
   <description>
     An application-layer encryption SDK that provides advanced encryption features and in depth defense against
@@ -38,7 +38,7 @@
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.25</slf4j.version>
-    <guava.version>24.1.1-jre</guava.version>
+    <guava.version>29.0-jre</guava.version>
     <aws.sdk.version>1.11.468</aws.sdk.version>
     <micrometer.version>1.1.1</micrometer.version>
     <caffeine.version>2.8.0</caffeine.version>

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -38,7 +38,7 @@
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.25</slf4j.version>
-    <guava.version>22.0</guava.version>
+    <guava.version>24.1.1-jre</guava.version>
     <aws.sdk.version>1.11.468</aws.sdk.version>
     <micrometer.version>1.1.1</micrometer.version>
     <caffeine.version>2.8.0</caffeine.version>


### PR DESCRIPTION
- Update Guava to use the latest version
- Bump AE to v0.1.2 for release