### PR TITLE
[C#] Update AwsKeyManagementServiceImplTest

### DIFF
--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Kms/AwsKeyManagementServiceImplTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Kms/AwsKeyManagementServiceImplTest.cs
@@ -364,7 +364,7 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Kms
             {
                 { EncryptedKey, Convert.ToBase64String(encryptedKey) },
                 {
-                    KmsKeksKey, new ConcurrentBag<object>
+                    KmsKeksKey, new List<object>
                     {
                         new Dictionary<string, object>
                         {
@@ -373,7 +373,7 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Kms
                             { EncryptedKek, Convert.ToBase64String(dataKeyCipherText) },
                         },
                         encryptKeyAndBuildResultJson,
-                    }.ToList()
+                    }
                 },
             });
             GenerateDataKeyResult generateDataKeyResult = new GenerateDataKeyResult

--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Kms/AwsKeyManagementServiceImplTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Kms/AwsKeyManagementServiceImplTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;

--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Kms/AwsKeyManagementServiceImplTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Kms/AwsKeyManagementServiceImplTest.cs
@@ -407,7 +407,7 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Kms
             Assert.Equal(new byte[] { 0, 0 }, dataKeyPlainText);
 
             // This is a workaround for https://github.com/JamesNK/Newtonsoft.Json/issues/1437
-            // If DeepEquals fails due ot mismatching array order, compare the elements individually
+            // If DeepEquals fails due to mismatching array order, compare the elements individually
             if (!JToken.DeepEquals(kmsKeyEnvelope, kmsKeyEnvelopeResult))
             {
                 JArray kmsKeyEnvelopeKmsKeks = JArray.FromObject(kmsKeyEnvelope[KmsKeksKey]


### PR DESCRIPTION
- Newtonsoft.Json has an [issue](https://github.com/JamesNK/Newtonsoft.Json/issues/1437) where DeepEquals fails when order of array elements is different. Adding a custom checker to verify if the test should really fail or if it's just failing due to the aforementioned issue.