### PR TITLE
Fix JavaDoc issues for AE v0.1.3 release

### DIFF
--- a/build/java/build.sh
+++ b/build/java/build.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-mvn javadoc:javadoc
 mvn -U compile

--- a/build/java/build.sh
+++ b/build/java/build.sh
@@ -2,4 +2,5 @@
 
 set -e
 
+mvn javadoc:javadoc
 mvn -U compile

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -102,6 +102,20 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${jacoco.version}</version>

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -398,19 +398,6 @@
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.1.1</version>
-            <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
             <executions>

--- a/java/app-encryption/src/main/java/com/godaddy/asherah/appencryption/SessionFactory.java
+++ b/java/app-encryption/src/main/java/com/godaddy/asherah/appencryption/SessionFactory.java
@@ -50,7 +50,7 @@ public class SessionFactory implements SafeAutoCloseable {
    *
    * @param productId A unique identifier for a product.
    * @param serviceId A unique identifier for a service.
-   * @param metastore A {@link Metastore} implementation used to store system & intermediate keys.
+   * @param metastore A {@link Metastore} implementation used to store system and intermediate keys.
    * @param systemKeyCache A {@link java.util.concurrent.ConcurrentSkipListMap} based implementation for caching
    *                       system keys.
    * @param cryptoPolicy A {@link CryptoPolicy} implementation that dictates the various behaviors of Asherah.

--- a/java/app-encryption/src/main/java/com/godaddy/asherah/appencryption/envelope/EnvelopeEncryptionJsonImpl.java
+++ b/java/app-encryption/src/main/java/com/godaddy/asherah/appencryption/envelope/EnvelopeEncryptionJsonImpl.java
@@ -43,7 +43,7 @@ public class EnvelopeEncryptionJsonImpl implements EnvelopeEncryption<JSONObject
    * implementation of {@link EnvelopeEncryption} which uses {@link org.json.JSONObject} as the Data Row Record format.
    *
    * @param partition A {@link Partition} object.
-   * @param metastore A {@link Metastore} implementation used to store system & intermediate keys.
+   * @param metastore A {@link Metastore} implementation used to store system and intermediate keys.
    * @param systemKeyCache A {@link java.util.concurrent.ConcurrentSkipListMap} based implementation for caching
    *                       system keys.
    * @param intermediateKeyCache A {@link java.util.concurrent.ConcurrentSkipListMap} based implementation for caching

--- a/java/app-encryption/src/main/java/com/godaddy/asherah/appencryption/envelope/EnvelopeEncryptionJsonImpl.java
+++ b/java/app-encryption/src/main/java/com/godaddy/asherah/appencryption/envelope/EnvelopeEncryptionJsonImpl.java
@@ -43,7 +43,7 @@ public class EnvelopeEncryptionJsonImpl implements EnvelopeEncryption<JSONObject
    * implementation of {@link EnvelopeEncryption} which uses {@link org.json.JSONObject} as the Data Row Record format.
    *
    * @param partition A {@link Partition} object.
-   * @param metastore A {@link Metastore} implementation used to store system and intermediate keys.
+   * @param metastore A {@link Metastore} implementation used to store system & intermediate keys.
    * @param systemKeyCache A {@link java.util.concurrent.ConcurrentSkipListMap} based implementation for caching
    *                       system keys.
    * @param intermediateKeyCache A {@link java.util.concurrent.ConcurrentSkipListMap} based implementation for caching


### PR DESCRIPTION
- Moved the `maven-javadoc-plugin` out of the release profile block. This will ensure that JavaDocs are generated and validated for every build.  