### PR TITLE
revert back to using coverlet.msbuild

### DIFF
--- a/csharp/SecureMemory/SecureMemory.Tests/SecureMemory.Tests.csproj
+++ b/csharp/SecureMemory/SecureMemory.Tests/SecureMemory.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This _should_ fix unit test code coverage.