### PR TITLE
[Java] app-encryption JDK 11 support (build env only)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
       - save-java-cache
   java-app-encryption:
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: cimg/openjdk:11.0
     steps:
       - checkout
       - restore-java-cache
@@ -649,11 +649,13 @@ jobs:
       - run:
           name: Setup java environment
           command: |
-            apt-get install -y openjdk-8-jdk
+            apt-get install -y openjdk-8-jdk openjdk-11-jdk
             apt-get install -y maven
             # Delete Java appencryption & gRPC server from local maven repo/cache and build from the current branch
             rm -rf ~/.m2/repository/com/godaddy/asherah/grpc-server ~/.m2/repository/com/godaddy/asherah/appencryption
+            export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
             mvn clean install -f java/app-encryption/pom.xml -DskipTests
+            export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
             mvn clean install -f server/java/pom.xml -DskipTests
       - run:
           name: Setup csharp environment

--- a/java/app-encryption/checkstyle.xml
+++ b/java/app-encryption/checkstyle.xml
@@ -74,6 +74,12 @@
     <!-- See http://checkstyle.sourceforge.net/config_filters.html#SuppressWarningsFilter -->
     <module name="SuppressWarningsFilter" />
 
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="LineLength">
+        <property name="max" value="120"/>
+    </module>
+
     <!-- Checks for Headers                                -->
     <!-- See http://checkstyle.sf.net/config_header.html   -->
     <!-- <module name="Header"> -->
@@ -115,11 +121,6 @@
             <property name="processJavadoc" value="false"/>
         </module>
 
-        <!-- Checks for Size Violations.                    -->
-        <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength">
-            <property name="max" value="120"/>
-        </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
 

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.godaddy.asherah</groupId>
   <artifactId>appencryption</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.4-alpha</version>
   <name>Asherah</name>
   <description>
     An application-layer encryption SDK that provides advanced encryption features and in depth defense against
@@ -232,7 +232,7 @@
     <dependency>
       <groupId>com.godaddy.asherah</groupId>
       <artifactId>securememory</artifactId>
-      <version>0.1.0</version>
+      <version>0.1.1</version>
     </dependency>
 
     <dependency>

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -38,16 +38,16 @@
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.30</slf4j.version>
     <guava.version>29.0-jre</guava.version>
     <aws.sdk.version>1.11.838</aws.sdk.version>
     <micrometer.version>1.1.1</micrometer.version>
     <caffeine.version>2.8.0</caffeine.version>
-    <junit.jupiter.version>5.1.1</junit.jupiter.version>
-    <junit.platform.version>1.1.1</junit.platform.version>
-    <mockito.core.version>2.22.0</mockito.core.version>
+    <junit.jupiter.version>5.7.0</junit.jupiter.version>
+    <junit.platform.version>1.7.0</junit.platform.version>
+    <mockito.core.version>3.5.13</mockito.core.version>
     <testcontainers.version>1.11.2</testcontainers.version>
-    <jacoco.version>0.8.2</jacoco.version>
+    <jacoco.version>0.8.6</jacoco.version>
     <amazonaws.version>1.11.477</amazonaws.version>
     <jackson.version>2.11.2</jackson.version>
     <apache.commons.version>1.8</apache.commons.version>
@@ -61,7 +61,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>validate</id>
@@ -82,16 +82,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>8</release>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -104,7 +103,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -142,7 +141,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-plugin</artifactId>
-        <version>1.10.0</version>
+        <version>1.11.2</version>
         <configuration>
           <connectionType>developerConnection</connectionType>
         </configuration>
@@ -192,7 +191,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
+        <version>3.1.2</version>
         <executions>
           <execution>
             <id>copy</id>

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.godaddy.asherah</groupId>
   <artifactId>appencryption</artifactId>
-  <version>0.1.4-alpha</version>
+  <version>0.1.4</version>
   <name>Asherah</name>
   <description>
     An application-layer encryption SDK that provides advanced encryption features and in depth defense against

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -40,18 +40,18 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <slf4j.version>1.7.30</slf4j.version>
     <guava.version>29.0-jre</guava.version>
-    <aws.sdk.version>1.11.838</aws.sdk.version>
-    <micrometer.version>1.1.1</micrometer.version>
-    <caffeine.version>2.8.0</caffeine.version>
+    <aws.sdk.version>1.11.871</aws.sdk.version>
+    <micrometer.version>1.5.5</micrometer.version>
+    <caffeine.version>2.8.5</caffeine.version>
     <junit.jupiter.version>5.7.0</junit.jupiter.version>
     <junit.platform.version>1.7.0</junit.platform.version>
     <mockito.core.version>3.5.13</mockito.core.version>
     <testcontainers.version>1.11.2</testcontainers.version>
     <jacoco.version>0.8.6</jacoco.version>
-    <amazonaws.version>1.11.477</amazonaws.version>
+    <amazonaws.version>1.13.4</amazonaws.version>
     <jackson.version>2.11.2</jackson.version>
-    <apache.commons.version>1.8</apache.commons.version>
-    <zaxxer.version>2.6.1</zaxxer.version>
+    <apache.commons.version>1.9</apache.commons.version>
+    <zaxxer.version>3.4.5</zaxxer.version>
     <checkstyle.config>${project.basedir}/checkstyle.xml</checkstyle.config>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
   </properties>
@@ -216,12 +216,12 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.1.3</version>
+        <version>1.2</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -256,14 +256,14 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20180130</version>
+      <version>20200518</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.64</version>
+      <version>1.66</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Compilation target continues to be JDK-8
- Upgraded dependencies, including secure-memory to v0.1.1
