### PR TITLE
Add creation stack trace debug mode for ProtectedMemorySecret

### DIFF
--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl;
 using Microsoft.Extensions.Configuration;
@@ -17,8 +18,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 
+            var configDictionary = new Dictionary<string, string>();
+            configDictionary["debugSecrets"] = "true";
+
             var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection()
+                .AddInMemoryCollection(configDictionary)
                 .Build();
 
             Debug.WriteLine("ProtectedMemorySecretFactoryTest ctor");

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -48,7 +48,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             protectedMemoryAllocatorMock.Setup(x => x.Alloc(It.IsAny<ulong>())).Returns(IntPtr.Zero);
             Assert.Throws<ProtectedMemoryAllocationFailedException>(() =>
             {
-                using (var secret = new ProtectedMemorySecret(new byte[] { 0, 1 }, protectedMemoryAllocatorMock.Object))
+                using (var secret = new ProtectedMemorySecret(new byte[] { 0, 1 }, protectedMemoryAllocatorMock.Object, configuration))
                 {
                 }
             });
@@ -61,7 +61,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretBytesAction");
             byte[] secretBytes = { 0, 1 };
             using (ProtectedMemorySecret secret =
-                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator))
+                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator, configuration))
             {
                 secret.WithSecretBytes(decryptedBytes =>
                 {
@@ -77,7 +77,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretBytesSuccess");
             byte[] secretBytes = { 0, 1 };
             using (ProtectedMemorySecret secret =
-                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator))
+                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator, configuration))
             {
                 secret.WithSecretBytes(decryptedBytes =>
                 {
@@ -94,7 +94,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretBytesWithClosedSecretShouldFail");
             byte[] secretBytes = { 0, 1 };
             ProtectedMemorySecret secret =
-                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator);
+                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator, configuration);
             secret.Close();
             Assert.Throws<InvalidOperationException>(() => { secret.WithSecretBytes(decryptedBytes => true); });
         }
@@ -106,7 +106,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretUtf8CharsAction");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator))
+                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
             {
                 secret.WithSecretUtf8Chars(decryptedChars =>
                 {
@@ -122,7 +122,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretUtf8CharsSuccess");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator))
+                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
             {
                 secret.WithSecretUtf8Chars(decryptedChars =>
                 {
@@ -139,7 +139,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretUtf8CharsWithClosedSecretShouldFail");
             char[] secretChars = { 'a', 'b' };
             ProtectedMemorySecret secret =
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator);
+                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration);
             secret.Close();
             Assert.Throws<InvalidOperationException>(() => { secret.WithSecretUtf8Chars(decryptedChars => true); });
         }
@@ -151,7 +151,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestCopySecret");
             byte[] secretBytes = { 0, 1 };
             using (ProtectedMemorySecret secret =
-                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator))
+                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator, configuration))
             {
                 using (ProtectedMemorySecret secretCopy = (ProtectedMemorySecret)secret.CopySecret())
                 {
@@ -176,7 +176,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
                     new Mock<MacOSProtectedMemoryAllocatorLP64> { CallBase = true };
 
                 ProtectedMemorySecret secret =
-                    new ProtectedMemorySecret(secretBytes, protectedMemoryAllocatorMacOSMock.Object);
+                    new ProtectedMemorySecret(secretBytes, protectedMemoryAllocatorMacOSMock.Object, configuration);
                 secret.Close();
                 secret.Close();
                 protectedMemoryAllocatorMacOSMock.Verify(
@@ -188,7 +188,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
                     new Mock<LinuxProtectedMemoryAllocatorLP64> { CallBase = true };
 
                 ProtectedMemorySecret secret =
-                    new ProtectedMemorySecret(secretBytes, protectedMemoryAllocatorLinuxMock.Object);
+                    new ProtectedMemorySecret(secretBytes, protectedMemoryAllocatorLinuxMock.Object, configuration);
                 secret.Close();
                 secret.Close();
                 protectedMemoryAllocatorLinuxMock.Verify(

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -29,8 +29,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 
+            var configDictionary = new Dictionary<string,string>();
+            configDictionary["debugSecrets"] = "true";
+
             configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection()
+                .AddInMemoryCollection(configDictionary)
                 .Build();
 
             Debug.WriteLine("\nProtectedMemorySecretTest ctor");

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
@@ -159,14 +159,8 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
             {
                 if (!disposing)
                 {
-                    if (creationStackTrace != null)
-                    {
-                        throw new Exception("FATAL: Reached finalizer for ProtectedMemorySecret (missing Dispose())\n" + creationStackTrace);
-                    }
-                    else
-                    {
-                        throw new Exception("FATAL: Reached finalizer for ProtectedMemorySecret (missing Dispose())");
-                    }
+                    const string exceptionMessage = "FATAL: Reached finalizer for ProtectedMemorySecret (missing Dispose())";
+                    throw new Exception(exceptionMessage + ((creationStackTrace == null) ? string.Empty : Environment.NewLine + creationStackTrace));
                 }
                 else
                 {

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
@@ -16,12 +16,14 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
         private static IProtectedMemoryAllocator allocator;
         private static int refCount = 0;
         private static object allocatorLock = new object();
+        private IConfiguration configuration;
 
         public ProtectedMemorySecretFactory(IConfiguration configuration = null)
         {
             Debug.WriteLine("ProtectedMemorySecretFactory ctor");
             lock (allocatorLock)
             {
+                this.configuration = configuration;
                 if (allocator != null)
                 {
                     refCount++;
@@ -46,12 +48,12 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
 
         public Secret CreateSecret(byte[] secretData)
         {
-            return new ProtectedMemorySecret(secretData, allocator);
+            return new ProtectedMemorySecret(secretData, allocator, configuration);
         }
 
         public Secret CreateSecret(char[] secretData)
         {
-            return ProtectedMemorySecret.FromCharArray(secretData, allocator);
+            return ProtectedMemorySecret.FromCharArray(secretData, allocator, configuration);
         }
 
         public void Dispose()


### PR DESCRIPTION
Since failure to Dispose of a ProtectedMemorySecret is now a fatal error, it becomes important to be able to figure out which secret usage isn't being disposed of.  Since the fatal error happens in the finalizer thread, there's no good way to identify that.  With this additional bit of configuration for debugging secrets enabled, ProtectedMemorySecret will save the stack trace of the constructor call and include that in the exception message if it hits the finalizer.