### PR TITLE
Replace codecov orb with a custom command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  codecov: codecov/codecov@1.1.1
-
 parameters:
   db-name:
     type: "string"
@@ -116,6 +113,35 @@ commands:
             else
               echo "WhiteSource scans will only run in the original repository"
             fi
+  upload-coverage:
+    parameters:
+      file:
+        type: string
+      flags:
+        type: string
+    steps:
+      - run:
+          name: Upload Coverage Results
+          command: |
+            upload() {
+              curl -s https://codecov.io/bash | bash -s -- \
+                -f "<<parameters.file>>" \
+                -t "${CODECOV_TOKEN}" \
+                -n "${CIRCLE_BUILD_NUM}" \
+                -F "<<parameters.flags>>" \
+                -Z
+            }
+
+            max_retries=5
+            retries=0
+            until upload; do
+                echo 'Codecov upload failed'
+                [[ $retries -eq $max_retries ]] && echo 'Giving up!' && exit 0
+                echo 'Retrying in 5 seconds'
+                sleep 5
+                (( retries++ ))
+            done
+            echo 'Codecov upload succeeded'
 
 workflows:
   version: 2
@@ -192,7 +218,7 @@ jobs:
             ./scripts/test.sh
       - store_test_results:
           path: java/secure-memory/target/surefire-reports
-      - codecov/upload:
+      - upload-coverage:
           file: java/secure-memory/target/site/jacoco/jacoco.xml
           flags: java_secure_memory
       - maybe-deploy:
@@ -225,7 +251,7 @@ jobs:
             ./scripts/integration_test.sh
       - store_test_results:
           path: java/app-encryption/target/surefire-reports
-      - codecov/upload:
+      - upload-coverage:
           file: java/app-encryption/target/site/jacoco/jacoco.xml
           flags: java_app_encryption
       - maybe-deploy:
@@ -275,7 +301,7 @@ jobs:
             ~/.dotnet/tools/trx2junit Logging.Tests/TestResults/*.trx
       - store_test_results:
           path: csharp/Logging/Logging.Tests/TestResults
-      - codecov/upload:
+      - upload-coverage:
           file: csharp/Logging/Logging.Tests/coverage.opencover.xml
           flags: csharp_Logging
       - maybe-deploy:
@@ -312,7 +338,7 @@ jobs:
             ~/.dotnet/tools/trx2junit SecureMemory.Tests/TestResults/*.trx
       - store_test_results:
           path: csharp/SecureMemory/SecureMemory.Tests/TestResults
-      - codecov/upload:
+      - upload-coverage:
           file: csharp/SecureMemory/SecureMemory.Tests/coverage.opencover.xml
           flags: csharp_SecureMemory
       - maybe-deploy:
@@ -355,7 +381,7 @@ jobs:
             ~/.dotnet/tools/trx2junit AppEncryption.Tests/TestResults/*.trx
       - store_test_results:
           path: csharp/AppEncryption/AppEncryption.Tests/TestResults
-      - codecov/upload:
+      - upload-coverage:
           file: csharp/AppEncryption/AppEncryption.Tests/coverage.opencover.xml
           flags: csharp_AppEncryption
       - run:
@@ -423,7 +449,7 @@ jobs:
             ./scripts/lint.sh
       - store_test_results:
           path: go/securememory
-      - codecov/upload:
+      - upload-coverage:
           file: go/securememory/cobertura-coverage.xml
           flags: go_securememory
       - maybe-deploy:
@@ -472,7 +498,7 @@ jobs:
             ./scripts/lint.sh
       - store_test_results:
           path: go/appencryption
-      - codecov/upload:
+      - upload-coverage:
           file: go/appencryption/cobertura-coverage.xml
           flags: go_appencryption
       - maybe-deploy:
@@ -527,7 +553,7 @@ jobs:
             ./scripts/lint.sh
       - store_test_results:
           path: server/go
-      - codecov/upload:
+      - upload-coverage:
           file: server/go/cobertura-coverage.xml
           flags: server_go
       - save-go-cache
@@ -551,7 +577,7 @@ jobs:
             ./scripts/test.sh
       - store_test_results:
           path: server/java/target/surefire-reports
-      - codecov/upload:
+      - upload-coverage:
           file: server/java/target/site/jacoco/jacoco.xml
           flags: server_java
       - save-java-cache


### PR DESCRIPTION
The new "upload-coverage" command makes use of the same bash script
as the codecov orb but wraps the execution in a retry loop.