### PR TITLE
upload-coverage bugfixss

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ commands:
           name: Upload Coverage Results
           command: |
             upload() {
+              echo 'Downloading and executing codecov bash'
               output="$(curl -s https://codecov.io/bash | bash -s -- \
                         -f "<<parameters.file>>" \
                         -t "${CODECOV_TOKEN}" \
@@ -131,7 +132,7 @@ commands:
                         -F "<<parameters.flags>>" \
                         -Z)"
               ec=$?
-              echo $output
+              echo "$output"
               return $ec
             }
 
@@ -142,7 +143,7 @@ commands:
                 [[ $retries -eq $max_retries ]] && echo 'Giving up!' && exit 0
                 echo 'Retrying in 5 seconds'
                 sleep 5
-                (( retries++ ))
+                let "retries=retries+1"
             done
             echo 'Codecov upload succeeded'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,12 +124,15 @@ commands:
           name: Upload Coverage Results
           command: |
             upload() {
-              curl -s https://codecov.io/bash | bash -s -- \
-                -f "<<parameters.file>>" \
-                -t "${CODECOV_TOKEN}" \
-                -n "${CIRCLE_BUILD_NUM}" \
-                -F "<<parameters.flags>>" \
-                -Z
+              output="$(curl -s https://codecov.io/bash | bash -s -- \
+                        -f "<<parameters.file>>" \
+                        -t "${CODECOV_TOKEN}" \
+                        -n "${CIRCLE_BUILD_NUM}" \
+                        -F "<<parameters.flags>>" \
+                        -Z)"
+              ec=$?
+              echo $output
+              return $ec
             }
 
             max_retries=5


### PR DESCRIPTION
- Execute codecov bash in subshell
- use let builtin for incrementing the counter, also avoid `(( var++ ))` exit code 1 on initial increment