### PR TITLE
Configure secret disposal requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ __pycache__/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# Visual Studio Code
+.vs/

--- a/build/csharp/release_prod.sh
+++ b/build/csharp/release_prod.sh
@@ -11,6 +11,7 @@ if [[ "$RESULT" != ${TAG} ]]; then
     dotnet pack -c Release --no-build
     echo "Releasing ${ARTIFACT_NAME} artifact"
     find . -name *${BASE_VERSION}.nupkg  | xargs -L1 -I '{}' dotnet nuget push {} -k ${NUGET_KEY} -s ${NUGET_SOURCE}
+    find . -name *${BASE_VERSION}.snupkg | xargs -L1 -I '{}' dotnet nuget push {} -k ${NUGET_KEY} -s ${NUGET_SOURCE}
 
     # Create tag
     git tag -f ${TAG} ${CIRCLE_SHA1}

--- a/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
+++ b/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
@@ -16,6 +16,8 @@
     <PackageProjectUrl>https://github.com/godaddy/asherah</PackageProjectUrl>
     <RepositoryUrl>https://github.com/godaddy/asherah/tree/master/csharp/AppEncryption</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <!-- End of Properties related to NuGet packaging: -->
   </PropertyGroup>
   <ItemGroup Label="Package References">

--- a/csharp/SecureMemory/Directory.Build.props
+++ b/csharp/SecureMemory/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.6</Version>
+    <Version>0.1.7</Version>
   </PropertyGroup>
 </Project>

--- a/csharp/SecureMemory/PlatformNative/PlatformNative.csproj
+++ b/csharp/SecureMemory/PlatformNative/PlatformNative.csproj
@@ -13,6 +13,8 @@
     <PackageProjectUrl>https://github.com/godaddy/asherah</PackageProjectUrl>
     <RepositoryUrl>https://github.com/godaddy/asherah/tree/master/csharp/SecureMemory/PlatformNative</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/SecureMemory/SecureMemory.Tests/EndToEndTests.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/EndToEndTests.cs
@@ -13,7 +13,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests
         [Fact]
         private void EndToEndTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 
@@ -43,7 +43,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests
         [Fact]
         private void EndToEndOpenSSLTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -59,15 +59,12 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
             libcProtectedMemoryAllocator?.Dispose();
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestDisableCoreDumpGlobally()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestDisableCoreDumpGlobally");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             // Mac allocator has global core dumps disabled on init
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -88,15 +85,12 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
             Assert.Equal(zeroRlimit.rlim_max, newRlimit.rlim_max);
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestAllocWithSetNoDumpErrorShouldFail()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestAllocWithSetNoDumpErrorShouldFail");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -118,15 +112,12 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
             }
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestCheckPointerWithRegularPointerShouldSucceed()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckPointerWithRegularPointerShouldSucceed");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             IntPtr pointer = libcProtectedMemoryAllocator.Alloc(1);
             try
@@ -139,15 +130,12 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
             }
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestCheckPointerWithNullPointerShouldFail()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckPointerWithNullPointerShouldFail");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             Assert.Throws<LibcOperationFailedException>(() =>
             {
@@ -155,15 +143,12 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
             });
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestCheckPointerWithMapFailedPointerShouldFail()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckPointerWithMapFailedPointerShouldFail");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             Assert.Throws<LibcOperationFailedException>(() =>
             {
@@ -171,54 +156,42 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
             });
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestCheckZeroWithZeroResult()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckZeroWithZeroResult");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             Check.Zero(0, "TestCheckZeroWithZeroResult");
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestCheckZeroWithNonZeroResult()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckZeroWithNonZeroResult");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             Assert.Throws<LibcOperationFailedException>(() => { Check.Zero(1, "IGNORE_INTENTIONAL_ERROR"); });
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestCheckZeroThrowableWithZeroResult()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckZeroThrowableWithZeroResult");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             Check.Zero(0, "TestCheckZeroThrowableWithZeroResult", new InvalidOperationException());
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestCheckZeroThrowableWithNonZeroResult()
         {
+            Skip.If(libc == null);
+
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckZeroThrowableWithNonZeroResult");
-            // Don't run libc tests on platforms that don't match libc/posix behaviors
-            if (libc == null)
-            {
-                return;
-            }
 
             Assert.Throws<LibcOperationFailedException>(() =>
             {

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -28,7 +28,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
 
         public LibcProtectedMemoryAllocatorTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/ResourceLimitTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/ResourceLimitTest.cs
@@ -1,4 +1,5 @@
 using GoDaddy.Asherah.PlatformNative.LP64.Libc;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
@@ -6,9 +7,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
     [Collection("Logger Fixture collection")]
     public class ResourceLimitTest
     {
-        [Fact]
+        [SkippableFact]
         private void TestZero()
         {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+
             rlimit zeroRlimit = rlimit.Zero();
             Assert.Equal(0UL, zeroRlimit.rlim_cur);
             Assert.Equal(0UL, zeroRlimit.rlim_max);

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
@@ -30,26 +30,20 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Debug.WriteLine("LinuxOpenSSL11ProtectedMemoryAllocatorTest Dispose\n");
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestGetResourceCore()
         {
-            Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest TestGetResourceCore");
-            if (linuxOpenSSL11ProtectedMemoryAllocatorLP64 == null)
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
+            Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest TestGetResourceCore");
             Assert.Equal(4, linuxOpenSSL11ProtectedMemoryAllocatorLP64.GetRlimitCoreResource());
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest TestGetResourceCore End");
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestAllocFree()
         {
-            if (linuxOpenSSL11ProtectedMemoryAllocatorLP64 == null)
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             byte[] origValue = { 1, 2, 3, 4 };
             ulong length = (ulong)origValue.Length;
@@ -70,13 +64,10 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             }
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestSetNoAccessAfterDispose()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
             linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(32000, 128);
@@ -90,13 +81,10 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Assert.Equal("Called SetNoAccess on disposed LinuxOpenSSL11ProtectedMemoryAllocatorLP64", exception.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestReadAccessAfterDispose()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
             linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(32000, 128);
@@ -110,13 +98,10 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Assert.Equal("Called SetReadAccess on disposed LinuxOpenSSL11ProtectedMemoryAllocatorLP64", exception.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestReadWriteAccessAfterDispose()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
             linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(32000, 128);
@@ -130,13 +115,10 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Assert.Equal("Called SetReadWriteAccess on disposed LinuxOpenSSL11ProtectedMemoryAllocatorLP64", exception.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestAllocAfterDispose()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
             linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(32000, 128);
@@ -150,13 +132,10 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Assert.Equal("Called Alloc on disposed LinuxOpenSSL11ProtectedMemoryAllocatorLP64", exception.Message);
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestFreeAfterDispose()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
             linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(32000, 128);

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
@@ -13,7 +13,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
 
         public LinuxOpenSSL11ProtectedMemoryAllocatorTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorTest.cs
@@ -13,7 +13,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
 
         public LinuxProtectedMemoryAllocatorTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorTest.cs
@@ -30,32 +30,27 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             linuxProtectedMemoryAllocator?.Dispose();
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestSetNoDumpInvalidLength()
         {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+
             IntPtr fakeValidPointer = IntPtr.Add(IntPtr.Zero, 1);
-            Assert.Throws<Exception>(() =>
-            linuxProtectedMemoryAllocator.SetNoDump(fakeValidPointer, 0));
+            Assert.Throws<Exception>(() => linuxProtectedMemoryAllocator.SetNoDump(fakeValidPointer, 0));
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestGetResourceCore()
         {
-            if (linuxProtectedMemoryAllocator == null)
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Assert.Equal(4, linuxProtectedMemoryAllocator.GetRlimitCoreResource());
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestAllocFree()
         {
-            if (linuxProtectedMemoryAllocator == null)
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             byte[] origValue = { 1, 2, 3, 4 };
             ulong length = (ulong)origValue.Length;

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorTest.cs
@@ -31,6 +31,14 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
         }
 
         [Fact]
+        private void TestSetNoDumpInvalidLength()
+        {
+            IntPtr fakeValidPointer = IntPtr.Add(IntPtr.Zero, 1);
+            Assert.Throws<Exception>(() =>
+            linuxProtectedMemoryAllocator.SetNoDump(fakeValidPointer, 0));
+        }
+
+        [Fact]
         private void TestGetResourceCore()
         {
             if (linuxProtectedMemoryAllocator == null)

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/OpenSSLCryptProtectMemoryTests.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/OpenSSLCryptProtectMemoryTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux;
+using Xunit;
+
+namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
+{
+    [Collection("Logger Fixture collection")]
+    public class OpenSSLCryptProtectMemoryTests : IDisposable
+    {
+        private readonly LinuxOpenSSL11ProtectedMemoryAllocatorLP64 linuxOpenSSL11ProtectedMemoryAllocatorLP64;
+
+        public OpenSSLCryptProtectMemoryTests()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
+                linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(32000, 128);
+            }
+        }
+
+        public void Dispose()
+        {
+            linuxOpenSSL11ProtectedMemoryAllocatorLP64.Dispose();
+        }
+
+        [Fact]
+        private void TestProtectAfterDispose()
+        {
+            var cryptProtectMemory = new OpenSSLCryptProtectMemory("aes-256-gcm", linuxOpenSSL11ProtectedMemoryAllocatorLP64);
+            cryptProtectMemory.Dispose();
+            Assert.Throws<Exception>(() => cryptProtectMemory.CryptProtectMemory(IntPtr.Zero, 0));
+        }
+
+        [Fact]
+        private void TestUnprotectAfterDispose()
+        {
+            var cryptProtectMemory = new OpenSSLCryptProtectMemory("aes-256-gcm", linuxOpenSSL11ProtectedMemoryAllocatorLP64);
+            cryptProtectMemory.Dispose();
+            Assert.Throws<Exception>(() => cryptProtectMemory.CryptUnprotectMemory(IntPtr.Zero, 0));
+        }
+    }
+}

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/OpenSSLCryptProtectMemoryTests.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/OpenSSLCryptProtectMemoryTests.cs
@@ -22,20 +22,24 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
 
         public void Dispose()
         {
-            linuxOpenSSL11ProtectedMemoryAllocatorLP64.Dispose();
+            linuxOpenSSL11ProtectedMemoryAllocatorLP64?.Dispose();
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestProtectAfterDispose()
         {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+
             var cryptProtectMemory = new OpenSSLCryptProtectMemory("aes-256-gcm", linuxOpenSSL11ProtectedMemoryAllocatorLP64);
             cryptProtectMemory.Dispose();
             Assert.Throws<Exception>(() => cryptProtectMemory.CryptProtectMemory(IntPtr.Zero, 0));
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestUnprotectAfterDispose()
         {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+
             var cryptProtectMemory = new OpenSSLCryptProtectMemory("aes-256-gcm", linuxOpenSSL11ProtectedMemoryAllocatorLP64);
             cryptProtectMemory.Dispose();
             Assert.Throws<Exception>(() => cryptProtectMemory.CryptUnprotectMemory(IntPtr.Zero, 0));

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
@@ -14,7 +14,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
 
         public ProtectedMemorySecretFactoryTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -25,7 +25,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
 
         public ProtectedMemorySecretTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -252,6 +252,48 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             });
         }
 
+        [Fact]
+        private void TestAllocatorSetNoDumpFailure()
+        {
+            Debug.WriteLine("TestCloseWithClosedSecretShouldNoop");
+            byte[] secretBytes = { 0, 1 };
+            IProtectedMemoryAllocator allocator = null;
+
+            // TODO : Need to determine if we can stub out the protectedMemoryAllocatorMock.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Mock<MacOSProtectedMemoryAllocatorLP64> protectedMemoryAllocatorMacOSMock =
+                    new Mock<MacOSProtectedMemoryAllocatorLP64> { CallBase = true };
+
+                protectedMemoryAllocatorMacOSMock.Setup(x => x.SetNoDump(It.IsAny<IntPtr>(), It.IsAny<ulong>()))
+                    .Throws(new Exception());
+
+                allocator = protectedMemoryAllocatorMacOSMock.Object;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Mock<LinuxOpenSSL11ProtectedMemoryAllocatorLP64> protectedMemoryAllocatorLinuxMock =
+                    new Mock<LinuxOpenSSL11ProtectedMemoryAllocatorLP64> { CallBase = true };
+
+                protectedMemoryAllocatorLinuxMock.Setup(x => x.SetNoDump(It.IsAny<IntPtr>(), It.IsAny<ulong>()))
+                    .Throws(new Exception());
+
+                allocator = protectedMemoryAllocatorLinuxMock.Object;
+            }
+            else
+            {
+                return;
+            }
+
+            Assert.Throws<Exception>(() =>
+            {
+                ProtectedMemorySecret secret =
+                    new ProtectedMemorySecret(secretBytes, allocator, configuration);
+
+                secret.Close();
+            });
+        }
+
         // Borderline integration test, but still runs fast and can help catch critical regression
         [Fact]
         private void TestWithSecretBytesMultiThreadedAccess()

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -273,7 +273,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 Mock<LinuxOpenSSL11ProtectedMemoryAllocatorLP64> protectedMemoryAllocatorLinuxMock =
-                    new Mock<LinuxOpenSSL11ProtectedMemoryAllocatorLP64>(32000, 128) { CallBase = true };
+                    new Mock<LinuxOpenSSL11ProtectedMemoryAllocatorLP64>((ulong)32000, 128) { CallBase = true };
 
                 protectedMemoryAllocatorLinuxMock.Setup(x => x.SetNoDump(It.IsAny<IntPtr>(), It.IsAny<ulong>()))
                     .Throws(new Exception());

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -273,7 +273,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 Mock<LinuxOpenSSL11ProtectedMemoryAllocatorLP64> protectedMemoryAllocatorLinuxMock =
-                    new Mock<LinuxOpenSSL11ProtectedMemoryAllocatorLP64> { CallBase = true };
+                    new Mock<LinuxOpenSSL11ProtectedMemoryAllocatorLP64>(32000, 128) { CallBase = true };
 
                 protectedMemoryAllocatorLinuxMock.Setup(x => x.SetNoDump(It.IsAny<IntPtr>(), It.IsAny<ulong>()))
                     .Throws(new Exception());

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -31,6 +31,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
 
             var configDictionary = new Dictionary<string,string>();
             configDictionary["debugSecrets"] = "true";
+            configDictionary["requireSecretDisposal"] = "true";
 
             configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(configDictionary)

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -213,7 +213,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         [Fact]
         private void TestAllocatorSetNoAccessFailure()
         {
-            Debug.WriteLine("TestCloseWithClosedSecretShouldNoop");
+            Debug.WriteLine("TestAllocatorSetNoAccessFailure");
             byte[] secretBytes = { 0, 1 };
             IProtectedMemoryAllocator allocator = null;
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -255,7 +255,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         [Fact]
         private void TestAllocatorSetNoDumpFailure()
         {
-            Debug.WriteLine("TestCloseWithClosedSecretShouldNoop");
+            Debug.WriteLine("TestAllocatorSetNoDumpFailure");
             byte[] secretBytes = { 0, 1 };
             IProtectedMemoryAllocator allocator = null;
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorTest.cs
@@ -13,7 +13,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Windows
 
         public WindowsProtectedMemoryAllocatorTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorTest.cs
@@ -28,13 +28,10 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Windows
             windowsProtectedMemoryAllocator?.Dispose();
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestAllocSuccess()
         {
-            if (windowsProtectedMemoryAllocator == null)
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
             IntPtr pointer = windowsProtectedMemoryAllocator.Alloc(1);
             try
@@ -49,13 +46,10 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Windows
             }
         }
 
-        [Fact]
+        [SkippableFact]
         private void TestZeroMemory()
         {
-            if (windowsProtectedMemoryAllocator == null)
-            {
-                return;
-            }
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
             byte[] origValue = { 1, 2, 3, 4 };
             ulong length = (ulong)origValue.Length;

--- a/csharp/SecureMemory/SecureMemory.Tests/SecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/SecretTest.cs
@@ -12,7 +12,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests
 
         public SecretTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory.Tests/SecureMemory.Tests.csproj
+++ b/csharp/SecureMemory/SecureMemory.Tests/SecureMemory.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/SecureMemory/SecureMemory.Tests/TransientSecretFactoryTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/TransientSecretFactoryTest.cs
@@ -13,7 +13,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests
 
         public TransientSecretFactoryTest()
         {
-            Trace.Listeners.RemoveAt(0);
+            Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
@@ -15,7 +15,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
 {
     internal class LinuxOpenSSL11ProtectedMemoryAllocatorLP64 : LinuxProtectedMemoryAllocatorLP64, IProtectedMemoryAllocator, IDisposable
     {
-        private static readonly IntPtr InvalidPointer = new IntPtr(-1);
         private readonly ulong blockSize;
         private LinuxOpenSSL11LP64 openSSL11;
         private OpenSSLCryptProtectMemory cryptProtectMemory;

--- a/csharp/SecureMemory/SecureMemory/SecureMemory.csproj
+++ b/csharp/SecureMemory/SecureMemory/SecureMemory.csproj
@@ -14,6 +14,8 @@
     <PackageProjectUrl>https://github.com/godaddy/asherah</PackageProjectUrl>
     <RepositoryUrl>https://github.com/godaddy/asherah/tree/master/csharp/SecureMemory</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR makes the requirement to Dispose of any ProtectedMemorySecret configurable since there are presently cases where not all AppEncryption tests can dispose of all secrets due to limitations in xunit.