### PR TITLE
New actions workflow: Sync release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
           command: |
             upload() {
               echo 'Downloading and executing codecov bash'
-              output="$(curl -s https://codecov.io/bash | bash -s -- \
+              output="$(curl -sS https://codecov.io/bash | bash -s -- \
                         -f "<<parameters.file>>" \
                         -t "${CODECOV_TOKEN}" \
                         -n "${CIRCLE_BUILD_NUM}" \

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -1,0 +1,23 @@
+name: Sync release branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Release branch to target'
+        default: 'release-0.1.x'
+        required: true
+
+jobs:
+  sync-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Merge master -> {RELEASE_TARGET}
+        uses: devmasx/merge-branch@v1.3.0
+        with:
+          type: now
+          head_to_merge: master
+          target_branch: ${{ github.event.inputs.target }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow automates the push from master -> release-x

Also, includes minor update to the existing upload-coverage build step to ensure curl errors are displayed. 