### PR TITLE
Update nuget dependency resolver

### DIFF
--- a/.circleci/wss-unified-agent.config
+++ b/.circleci/wss-unified-agent.config
@@ -73,7 +73,7 @@ sendLogsToWss=true
 resolveAllDependencies=false
 #excludeDependenciesFromNodes=.*commons-io.*,.*maven-model
 
-npm.resolveDependencies=false
+#npm.resolveDependencies=false
 #npm.ignoreSourceFiles=false
 #npm.includeDevDependencies=true
 #npm.runPreStep=true
@@ -91,6 +91,7 @@ npm.resolveDependencies=false
 #npm.resolveGlobalPackages=true
 #npm.resolveLockFile=true
 
+nuget.resolveDependencies=true
 nuget.resolvePackagesConfigFiles=false
 nuget.resolveCsProjFiles=true
 nuget.resolveAssetsFiles=true


### PR DESCRIPTION
Set `nuget.resolveDependencies` to true so that all dependencies are resolved before running the scan. This should take care of the libraries not getting updated correctly for the C# projects.