### PR TITLE
Fix the locking on ProtectedMemorySecret

### DIFF
--- a/csharp/SecureMemory/Directory.Build.props
+++ b/csharp/SecureMemory/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.8</Version>
+    <Version>0.1.9</Version>
   </PropertyGroup>
 </Project>

--- a/csharp/SecureMemory/PlatformNative/LP64/Linux/OpenSSLCrypto.cs
+++ b/csharp/SecureMemory/PlatformNative/LP64/Linux/OpenSSLCrypto.cs
@@ -24,14 +24,6 @@ namespace GoDaddy.Asherah.PlatformNative.LP64.Linux
             return _EVP_CIPHER_CTX_new();
         }
 
-        [DllImport(LibraryName, EntryPoint = "EVP_CIPHER_CTX_reset", SetLastError = true)]
-        private static extern int _EVP_CIPHER_CTX_reset(IntPtr ctx);
-
-        public int EVP_CIPHER_CTX_reset(IntPtr ctx)
-        {
-            return _EVP_CIPHER_CTX_reset(ctx);
-        }
-
         [DllImport(LibraryName, EntryPoint = "EVP_CIPHER_CTX_free", SetLastError = true)]
         private static extern void _EVP_CIPHER_CTX_free(IntPtr ctx);
 
@@ -126,14 +118,6 @@ namespace GoDaddy.Asherah.PlatformNative.LP64.Linux
         public int RAND_bytes(IntPtr buf, int num)
         {
             return _RAND_bytes(buf, num);
-        }
-
-        [DllImport(LibraryName, EntryPoint = "EVP_CIPHER_CTX_block_size", SetLastError = true)]
-        private static extern int _EVP_CIPHER_CTX_block_size(IntPtr e);
-
-        public int EVP_CIPHER_CTX_block_size(IntPtr e)
-        {
-            return _EVP_CIPHER_CTX_block_size(e);
         }
 
         [DllImport(LibraryName, EntryPoint = "EVP_CIPHER_block_size", SetLastError = true)]

--- a/csharp/SecureMemory/PlatformNative/LP64/MacOS/MacOSLibcLP64.cs
+++ b/csharp/SecureMemory/PlatformNative/LP64/MacOS/MacOSLibcLP64.cs
@@ -23,6 +23,7 @@ namespace GoDaddy.Asherah.PlatformNative.LP64.MacOS
         [DllImport("libc", EntryPoint = "memset_s", SetLastError = true)]
         private static extern int _memset_s(IntPtr dest, size_t destSize, int val, size_t count);
 
+        [ExcludeFromCodeCoverage]
         public int memset_s(IntPtr dest, size_t destSize, int val, size_t count)
         {
             return _memset_s(dest, destSize, val, count);

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -130,6 +130,17 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
         }
 
         [SkippableFact]
+        private void TestFreeWithInvalidLengthShouldFail()
+        {
+            Skip.If(libc == null);
+
+            Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckPointerWithRegularPointerShouldSucceed");
+
+            IntPtr fakePtr = IntPtr.Add(IntPtr.Zero, 1);
+            Assert.Throws<LibcOperationFailedException>(() => libcProtectedMemoryAllocator.Free(fakePtr, 0));
+        }
+
+        [SkippableFact]
         private void TestCheckPointerWithNullPointerShouldFail()
         {
             Skip.If(libc == null);

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -134,7 +134,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
         {
             Skip.If(libc == null);
 
-            Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestCheckPointerWithRegularPointerShouldSucceed");
+            Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestFreeWithInvalidLengthShouldFail");
 
             IntPtr fakePtr = IntPtr.Add(IntPtr.Zero, 1);
             Assert.Throws<LibcOperationFailedException>(() => libcProtectedMemoryAllocator.Free(fakePtr, 0));

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl;
 using Microsoft.Extensions.Configuration;
 using Xunit;
@@ -43,18 +44,50 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         {
         }
 
+        [SkippableFact]
+        private void TestOpenSSLConfiguration()
+        {
+            Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
+            {
+                {"secureHeapEngine", "openssl11"}
+            }).Build();
+
+            Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestOpenSSLConfiguration");
+            using (var factory = new ProtectedMemorySecretFactory(configuration))
+            {
+            }
+        }
+
+        [Fact]
+        private void TestMmapConfiguration()
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
+            {
+                {"secureHeapEngine", "mmap"}
+            }).Build();
+
+            Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestMmapConfiguration");
+            using (var factory = new ProtectedMemorySecretFactory(configuration))
+            {
+            }
+        }
+
         [Fact]
         private void TestInvalidConfiguration()
         {
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
             {
-                {"secureHeapEngine", "openssl11"}  // Note the missing "required" settings
+                {"secureHeapEngine", "magic-heap-engine2"}
             }).Build();
 
-            Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestInvalidConfiguration");
-            using (var factory = new ProtectedMemorySecretFactory(configuration))
+            Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestMmapConfiguration");
+            Assert.Throws<PlatformNotSupportedException>(() =>
             {
-            }
+                using (var factory = new ProtectedMemorySecretFactory(configuration))
+                {
+                }
+            });
         }
 
         [Fact]

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -148,6 +148,60 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
 
         [Theory]
         [ClassData(typeof(AllocatorGenerator))]
+        private void TestWithSecretIntPtrSuccess(IProtectedMemoryAllocator protectedMemoryAllocator)
+        {
+            Debug.WriteLine("TestWithSecretUtf8CharsSuccess");
+            char[] secretChars = { 'a', 'b' };
+            using (ProtectedMemorySecret secret =
+                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
+            {
+                secret.WithSecretIntPtr((ptr, len) =>
+                {
+                    Assert.NotEqual(ptr, IntPtr.Zero);
+                    Assert.True(len == 2);
+                    return true;
+                });
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(AllocatorGenerator))]
+        private void TestWithSecretIntPtrDisposed(IProtectedMemoryAllocator protectedMemoryAllocator)
+        {
+            Debug.WriteLine("TestWithSecretIntPtrDisposed");
+            char[] secretChars = { 'a', 'b' };
+            ProtectedMemorySecret secret =
+                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration);
+
+            secret.Dispose();
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                secret.WithSecretIntPtr((ptr, len) =>
+                {
+                    return true;
+                });
+            });
+        }
+
+        [Theory]
+        [ClassData(typeof(AllocatorGenerator))]
+        private void TestWithSecretIntPtrActionSuccess(IProtectedMemoryAllocator protectedMemoryAllocator)
+        {
+            Debug.WriteLine("TestWithSecretUtf8CharsSuccess");
+            char[] secretChars = { 'a', 'b' };
+            using (ProtectedMemorySecret secret =
+                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
+            {
+                secret.WithSecretIntPtr((ptr, len) =>
+                {
+                    Assert.NotEqual(ptr, IntPtr.Zero);
+                    Assert.True(len == 2);
+                });
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(AllocatorGenerator))]
         private void TestWithSecretUtf8CharsWithClosedSecretShouldFail(IProtectedMemoryAllocator protectedMemoryAllocator)
         {
             Debug.WriteLine("TestWithSecretUtf8CharsWithClosedSecretShouldFail");

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -150,7 +150,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         [ClassData(typeof(AllocatorGenerator))]
         private void TestWithSecretIntPtrSuccess(IProtectedMemoryAllocator protectedMemoryAllocator)
         {
-            Debug.WriteLine("TestWithSecretUtf8CharsSuccess");
+            Debug.WriteLine("TestWithSecretIntPtrSuccess");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
                 ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -245,10 +245,8 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
 
             Assert.Throws<Exception>(() =>
             {
-                ProtectedMemorySecret secret =
+                using ProtectedMemorySecret secret =
                     new ProtectedMemorySecret(secretBytes, allocator, configuration);
-
-                secret.Close();
             });
         }
 
@@ -287,10 +285,8 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
 
             Assert.Throws<Exception>(() =>
             {
-                ProtectedMemorySecret secret =
+                using ProtectedMemorySecret secret =
                     new ProtectedMemorySecret(secretBytes, allocator, configuration);
-
-                secret.Close();
             });
         }
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -187,7 +187,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         [ClassData(typeof(AllocatorGenerator))]
         private void TestWithSecretIntPtrActionSuccess(IProtectedMemoryAllocator protectedMemoryAllocator)
         {
-            Debug.WriteLine("TestWithSecretUtf8CharsSuccess");
+            Debug.WriteLine("TestWithSecretIntPtrActionSuccess");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
                 ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))

--- a/csharp/SecureMemory/SecureMemory.Tests/SecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/SecretTest.cs
@@ -62,7 +62,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests
         [Fact]
         private void TestWithSecretIntPtrAction()
         {
-            Debug.WriteLine("\nTestWithSecretIntPtrActionOfChar: Start");
+            Debug.WriteLine("\nTestWithSecretIntPtrAction: Start");
             char[] secretChars = { (char)0, (char)1 };
 
             Action<IntPtr, ulong> actionWithSecret = (ptr, len) =>

--- a/csharp/SecureMemory/SecureMemory.Tests/SecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/SecretTest.cs
@@ -58,5 +58,25 @@ namespace GoDaddy.Asherah.SecureMemory.Tests
             secretMock.Object.WithSecretUtf8Chars(actionWithSecret);
             Debug.WriteLine("TestWithSecretUtf8CharsActionOfChar: Finish\n");
         }
+
+        [Fact]
+        private void TestWithSecretIntPtrAction()
+        {
+            Debug.WriteLine("\nTestWithSecretIntPtrActionOfChar: Start");
+            char[] secretChars = { (char)0, (char)1 };
+
+            Action<IntPtr, ulong> actionWithSecret = (ptr, len) =>
+            {
+                Assert.Equal(IntPtr.Add(IntPtr.Zero, 1), ptr);
+                Assert.True(len == 1);
+            };
+
+            secretMock.Setup(x => x.WithSecretIntPtr(It.IsAny<Action<IntPtr, ulong>>())).CallBase();
+            secretMock.Setup(x => x.WithSecretIntPtr(It.IsAny<Func<IntPtr, ulong, bool>>()))
+                .Returns<Func<IntPtr, ulong, bool>>(action => action(
+                    IntPtr.Add(IntPtr.Zero, 1), 1));
+            secretMock.Object.WithSecretIntPtr(actionWithSecret);
+            Debug.WriteLine("TestWithSecretIntPtrActionOfChar: Finish\n");
+        }
     }
 }

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
@@ -48,13 +48,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc
         // ************************************
         public virtual IntPtr Alloc(ulong length)
         {
-            libc.getrlimit(GetMemLockLimit(), out var rlim);
-            if (rlim.rlim_max != rlimit.UNLIMITED && rlim.rlim_max < length)
-            {
-                throw new MemoryLimitException(
-                    $"Requested MemLock length exceeds resource limit max of {rlim.rlim_max}");
-            }
-
             // Some platforms may require fd to be -1 even if using anonymous
             IntPtr protectedMemory = libc.mmap(
                 IntPtr.Zero, length, GetProtReadWrite(), GetPrivateAnonymousFlags(), -1, 0);

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
@@ -9,8 +9,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc
 {
     internal abstract class LibcProtectedMemoryAllocatorLP64 : IProtectedMemoryAllocator
     {
-        private static readonly IntPtr InvalidPointer = new IntPtr(-1);
-
         private readonly LibcLP64 libc;
 
         private bool globallyDisabledCoreDumps = false;

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
@@ -22,10 +22,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
             : base(new LinuxOpenSSL11LP64())
         {
             openSSL11 = (LinuxOpenSSL11LP64)GetLibc();
-            if (openSSL11 == null)
-            {
-                throw new Exception("GetLibc returned null object for openSSL11");
-            }
 
             ulong heapSize;
             var heapSizeConfig = configuration["heapSize"];

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
@@ -275,20 +275,16 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
         private void SetReadAccessIfNeeded()
         {
             // Only set read access if we're the first one trying to access this potentially-shared Secret
-            if (accessCounter == 0)
+            if (Interlocked.Increment(ref accessCounter) == 1)
             {
                 allocator.SetReadAccess(pointer, length);
             }
-
-            accessCounter++;
         }
 
         private void SetNoAccessIfNeeded()
         {
-            accessCounter--;
-
             // Only set no access if we're the last one trying to access this potentially-shared Secret
-            if (accessCounter == 0)
+            if (Interlocked.Decrement(ref accessCounter) == 0)
             {
                 allocator.SetNoAccess(pointer, length);
             }

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
@@ -205,13 +205,13 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
 
         protected virtual void Dispose(bool disposing)
         {
-            if (pointer == IntPtr.Zero)
-            {
-                return;
-            }
-
             if (!disposing)
             {
+                if (pointer == IntPtr.Zero)
+                {
+                    return;
+                }
+
                 if (requireSecretDisposal)
                 {
                     const string exceptionMessage = "FATAL: Reached finalizer for ProtectedMemorySecret (missing Dispose())";
@@ -226,10 +226,15 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                 pointerLock.EnterWriteLock();
                 try
                 {
+                    if (pointer == IntPtr.Zero)
+                    {
+                        return;
+                    }
 #if DEBUG
                     // TODO Add/uncomment this when we refactor logging to use static creation
                     // log.LogDebug("closing: {pointer}", ptr);
 #endif
+
                     // accessLock isn't needed here since we are holding the pointer lock in write
                     try
                     {

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
@@ -66,6 +66,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                 finally
                 {
                     this.allocator.Free(pointer, length);
+                    pointer = IntPtr.Zero;
                 }
 
                 throw;

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
@@ -153,6 +153,26 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                if (configuration != null)
+                {
+                    var secureHeapEngine = configuration["secureHeapEngine"];
+                    if (!string.IsNullOrWhiteSpace(secureHeapEngine))
+                    {
+                        if (string.Compare(secureHeapEngine, "openssl11", StringComparison.InvariantCultureIgnoreCase) == 0)
+                        {
+                            throw new PlatformNotSupportedException(
+                                "OpenSSL 1.1 selected for secureHeapEngine but not supported on Windows");
+                        }
+
+                        if (string.Compare(secureHeapEngine, "mmap", StringComparison.InvariantCultureIgnoreCase) == 0)
+                        {
+                            return new WindowsProtectedMemoryAllocatorVirtualAlloc(configuration);
+                        }
+
+                        throw new PlatformNotSupportedException("Unknown secureHeapEngine: " + secureHeapEngine);
+                    }
+                }
+
                 return new WindowsProtectedMemoryAllocatorVirtualAlloc(configuration);
             }
 

--- a/csharp/SecureMemory/SecureMemory/Secret.cs
+++ b/csharp/SecureMemory/SecureMemory/Secret.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace GoDaddy.Asherah.SecureMemory
 {
@@ -7,6 +8,8 @@ namespace GoDaddy.Asherah.SecureMemory
         public abstract TResult WithSecretBytes<TResult>(Func<byte[], TResult> funcWithSecret);
 
         public abstract TResult WithSecretUtf8Chars<TResult>(Func<char[], TResult> funcWithSecret);
+
+        public abstract TResult WithSecretIntPtr<TResult>(Func<IntPtr, ulong, TResult> funcWithSecret);
 
         public virtual void WithSecretBytes(Action<byte[]> actionWithSecret)
         {
@@ -22,6 +25,15 @@ namespace GoDaddy.Asherah.SecureMemory
             WithSecretUtf8Chars(chars =>
             {
                 actionWithSecret(chars);
+                return true;
+            });
+        }
+
+        public virtual void WithSecretIntPtr(Action<IntPtr, ulong> actionWithSecret)
+        {
+            WithSecretIntPtr((ptr, len) =>
+            {
+                actionWithSecret(ptr, len);
                 return true;
             });
         }


### PR DESCRIPTION
The locking on ProtectedMemorySecret wasn't done correctly, and it wasn't being caught well by the tests back when we weren't universally calling Dispose.  When we started calling Dispose more often, we would get phantom errors during or after Dispose calls when Interlocked.Exchange would yank the pointer away after the IntPtr.Zero / null check outside of any synchronized context.

In this new version, we use a ReaderWriterLockSlim.EnterReadLock for all read access to the secret, and we use ReaderWriterLockSlim.EnterWriteLock for Dispose.  This allows multiple concurrent readers of the same secret unlike the previous version, and ensures a synchronized context when disposing.

Also in this PR, we ensure that the managed byte[] and managed char[] used in WithSecretBytes and WithSecretUtf8Chars (which is misnamed) are both GC pinned while they're being accessed until they're wiped.  This keeps the garbage collector from relocating them and potentially leaking copies of the secrets.

This also introduces WithSecretIntPtr which allows for the unmanaged pointer to be used directly with other unmanaged calls like OpenSSL crypto calls in future work.
