### PR TITLE
Secure memory enhancements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
     -   id: check-xml
     -   id: check-toml
     -   id: detect-private-key
-    -   id: end-of-file-fixer
     -   id: forbid-new-submodules
     -   id: mixed-line-ending
     -   id: check-added-large-files

--- a/codecov.yml
+++ b/codecov.yml
@@ -73,6 +73,8 @@ ignore:
   # Non-linux native paths. Ideally, be nice to setup separate OS-specific builds.
   - "**/com/godaddy/asherah/securememory/protectedmemoryimpl/macos" # java macOS path
   - "**/SecureMemory/ProtectedMemoryImpl/MacOS" # C# macOS path
+  - "**/SecureMemory/PlatformNative/LP64/MacOS" # C# macOS path
+  - "**/SecureMemory/PlatformNative/LLP64/Windows" # C# Windows path
   - "**/SecureMemory/ProtectedMemoryImpl/Windows" # C# Windows path
   # gRPC auto-generated file
   - "**/target/generated-sources/protobuf" # Java auto-generated files

--- a/csharp/SecureMemory/Directory.Build.props
+++ b/csharp/SecureMemory/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.9</Version>
+    <Version>0.1.10</Version>
   </PropertyGroup>
 </Project>

--- a/csharp/SecureMemory/PlatformNative/LLP64/Windows/WindowsInterop.cs
+++ b/csharp/SecureMemory/PlatformNative/LLP64/Windows/WindowsInterop.cs
@@ -39,7 +39,7 @@ namespace GoDaddy.Asherah.PlatformNative.LLP64.Windows
         [DllImport("Kernel32.dll", EntryPoint = "RtlZeroMemory", SetLastError = true, ExactSpelling = true)]
         internal static extern void ZeroMemory(IntPtr dest, UIntPtr size);
 
-        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
+        [DllImport("kernel32.dll", EntryPoint = "RtlCopyMemory", SetLastError = false)]
         internal static extern void CopyMemory(IntPtr dest, IntPtr src, UIntPtr count);
     }
 }

--- a/csharp/SecureMemory/PlatformNative/LLP64/Windows/WindowsInterop.cs
+++ b/csharp/SecureMemory/PlatformNative/LLP64/Windows/WindowsInterop.cs
@@ -6,9 +6,6 @@ namespace GoDaddy.Asherah.PlatformNative.LLP64.Windows
 {
     public class WindowsInterop
     {
-        [DllImport("Kernel32.dll", EntryPoint="RtlZeroMemory", SetLastError=true, ExactSpelling=true)]
-        public static extern void ZeroMemory(IntPtr dest, UIntPtr size);
-
         [DllImport("kernel32.dll", SetLastError=true, ExactSpelling=true)]
         public static extern IntPtr VirtualAlloc(IntPtr lpAddress, UIntPtr dwSize, AllocationType flAllocationType, MemoryProtection flProtect);
 
@@ -38,5 +35,11 @@ namespace GoDaddy.Asherah.PlatformNative.LLP64.Windows
 
         [DllImport("crypt32.dll", SetLastError=true)]
         public static extern bool CryptUnprotectMemory(IntPtr ptr, UIntPtr dwSize, CryptProtectMemoryOptions dwFlags);
+
+        [DllImport("Kernel32.dll", EntryPoint = "RtlZeroMemory", SetLastError = true, ExactSpelling = true)]
+        internal static extern void ZeroMemory(IntPtr dest, UIntPtr size);
+
+        [DllImport("kernel32.dll", EntryPoint = "CopyMemory", SetLastError = false)]
+        internal static extern void CopyMemory(IntPtr dest, IntPtr src, UIntPtr count);
     }
 }

--- a/csharp/SecureMemory/PlatformNative/LLP64/Windows/WindowsSystemInterfaceImpl.cs
+++ b/csharp/SecureMemory/PlatformNative/LLP64/Windows/WindowsSystemInterfaceImpl.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GoDaddy.Asherah.PlatformNative.LLP64.Windows
+{
+    internal class WindowsSystemInterfaceImpl : SystemInterface
+    {
+        public override void CopyMemory(IntPtr source, IntPtr dest, ulong length)
+        {
+            WindowsInterop.CopyMemory(dest, source, UIntPtr.Add(UIntPtr.Zero, (int)length));
+        }
+
+        public override void ZeroMemory(IntPtr ptr, ulong length)
+        {
+            WindowsInterop.ZeroMemory(ptr, UIntPtr.Add(UIntPtr.Zero, (int)length));
+        }
+    }
+}

--- a/csharp/SecureMemory/PlatformNative/LLP64/Windows/WindowsSystemInterfaceImpl.cs
+++ b/csharp/SecureMemory/PlatformNative/LLP64/Windows/WindowsSystemInterfaceImpl.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GoDaddy.Asherah.PlatformNative.LLP64.Windows
 {

--- a/csharp/SecureMemory/PlatformNative/LP64/Libc/LibcLP64.cs
+++ b/csharp/SecureMemory/PlatformNative/LP64/Libc/LibcLP64.cs
@@ -16,6 +16,14 @@ namespace GoDaddy.Asherah.PlatformNative.LP64.Libc
     [SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1202:ElementsMustBeOrderedByAccess", Justification = "Matching native conventions")]
     public class LibcLP64
     {
+        [DllImport("libc", EntryPoint = "memcpy", SetLastError = true)]
+        private static extern IntPtr _memcpy(IntPtr dest, IntPtr src, size_t len);
+
+        public IntPtr memcpy(IntPtr dest, IntPtr src, size_t len)
+        {
+            return _memcpy(dest, src, len);
+        }
+
         // **********************************************************************************************
         // madvise
         // int madvise(void *addr, size_t length, int advice);

--- a/csharp/SecureMemory/PlatformNative/LP64/Linux/LinuxLibcLP64.cs
+++ b/csharp/SecureMemory/PlatformNative/LP64/Linux/LinuxLibcLP64.cs
@@ -29,13 +29,5 @@ namespace GoDaddy.Asherah.PlatformNative.LP64.Linux
             // NOTE: there was a note in the java repo that glibc didn't have explicit_bzero?
             _bzero(start, len);
         }
-
-        [DllImport("libc", EntryPoint = "memcpy", SetLastError = true)]
-        private static extern IntPtr _memcpy(IntPtr dest, IntPtr src, size_t len);
-
-        public IntPtr memcpy(IntPtr dest, IntPtr src, size_t len)
-        {
-            return _memcpy(dest, src, len);
-        }
     }
 }

--- a/csharp/SecureMemory/PlatformNative/LP64/Linux/LinuxSystemInterfaceImpl.cs
+++ b/csharp/SecureMemory/PlatformNative/LP64/Linux/LinuxSystemInterfaceImpl.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GoDaddy.Asherah.PlatformNative.LP64.Linux
+{
+    internal class LinuxSystemInterfaceImpl : SystemInterface
+    {
+        private readonly LinuxLibcLP64 libc;
+
+        public LinuxSystemInterfaceImpl(LinuxLibcLP64 libc)
+        {
+            this.libc = libc;
+        }
+
+        public override void CopyMemory(IntPtr source, IntPtr dest, ulong length)
+        {
+            libc.memcpy(dest, source, length);
+        }
+
+        public override void ZeroMemory(IntPtr ptr, ulong length)
+        {
+            libc.bzero(ptr, length);
+        }
+    }
+}

--- a/csharp/SecureMemory/PlatformNative/LP64/Linux/LinuxSystemInterfaceImpl.cs
+++ b/csharp/SecureMemory/PlatformNative/LP64/Linux/LinuxSystemInterfaceImpl.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GoDaddy.Asherah.PlatformNative.LP64.Linux
 {

--- a/csharp/SecureMemory/PlatformNative/LP64/MacOS/MacOSSystemInterfaceImpl.cs
+++ b/csharp/SecureMemory/PlatformNative/LP64/MacOS/MacOSSystemInterfaceImpl.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GoDaddy.Asherah.PlatformNative.LP64.MacOS
+{
+    internal class MacOSSystemInterfaceImpl : SystemInterface
+    {
+        private readonly MacOSLibcLP64 libc;
+
+        public MacOSSystemInterfaceImpl(MacOSLibcLP64 libc)
+        {
+            this.libc = libc;
+        }
+
+        public override void CopyMemory(IntPtr source, IntPtr dest, ulong length)
+        {
+            libc.memcpy(dest, source, length);
+        }
+
+        public override void ZeroMemory(IntPtr ptr, ulong length)
+        {
+            libc.memset_s(ptr, length, 0, length);
+        }
+    }
+}

--- a/csharp/SecureMemory/PlatformNative/LP64/MacOS/MacOSSystemInterfaceImpl.cs
+++ b/csharp/SecureMemory/PlatformNative/LP64/MacOS/MacOSSystemInterfaceImpl.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace GoDaddy.Asherah.PlatformNative.LP64.MacOS
 {

--- a/csharp/SecureMemory/PlatformNative/SystemInterface.cs
+++ b/csharp/SecureMemory/PlatformNative/SystemInterface.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using GoDaddy.Asherah.PlatformNative.LLP64.Windows;
+using GoDaddy.Asherah.PlatformNative.LP64.Linux;
+using GoDaddy.Asherah.PlatformNative.LP64.MacOS;
+
+namespace GoDaddy.Asherah.PlatformNative
+{
+    public abstract class SystemInterface
+    {
+        private static readonly SystemInterface Interface;
+
+        static SystemInterface()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Interface = new LinuxSystemInterfaceImpl(new LinuxLibcLP64());
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Interface = new MacOSSystemInterfaceImpl(new MacOSLibcLP64());
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Interface = new WindowsSystemInterfaceImpl();
+            }
+        }
+
+        public static SystemInterface GetInstance()
+        {
+            if (Interface == null)
+            {
+                throw new PlatformNotSupportedException("Unknown platform");
+            }
+
+            return Interface;
+        }
+
+        public abstract void CopyMemory(IntPtr source, IntPtr dest, ulong length);
+
+        public abstract void ZeroMemory(IntPtr ptr, ulong length);
+    }
+}

--- a/csharp/SecureMemory/PlatformNative/SystemInterface.cs
+++ b/csharp/SecureMemory/PlatformNative/SystemInterface.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using GoDaddy.Asherah.PlatformNative.LLP64.Windows;
 using GoDaddy.Asherah.PlatformNative.LP64.Linux;
@@ -10,6 +11,7 @@ namespace GoDaddy.Asherah.PlatformNative
     {
         private static readonly SystemInterface Interface;
 
+        [ExcludeFromCodeCoverage]
         static SystemInterface()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -28,6 +30,7 @@ namespace GoDaddy.Asherah.PlatformNative
             }
         }
 
+        [ExcludeFromCodeCoverage]
         public static SystemInterface GetInstance()
         {
             if (Interface == null)

--- a/csharp/SecureMemory/PlatformNative/SystemInterface.cs
+++ b/csharp/SecureMemory/PlatformNative/SystemInterface.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 using GoDaddy.Asherah.PlatformNative.LLP64.Windows;
 using GoDaddy.Asherah.PlatformNative.LP64.Linux;
 using GoDaddy.Asherah.PlatformNative.LP64.MacOS;

--- a/csharp/SecureMemory/SecureMemory.Tests/CheckTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/CheckTest.cs
@@ -57,6 +57,17 @@ namespace GoDaddy.Asherah.SecureMemory.Tests
         }
 
         [Fact]
+        private void CheckZeroException()
+        {
+            var exception = Assert.Throws<LibcOperationFailedException>(() =>
+            {
+                Check.Zero(10, "CheckBadZero", new Exception("Exception in progress to set as inner exception"));
+            });
+
+            Assert.NotNull(exception.InnerException);
+        }
+
+        [Fact]
         private void CheckBadZero()
         {
             Assert.Throws<LibcOperationFailedException>(() =>

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/AllocatorGenerator.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/AllocatorGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.MacOS;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Windows;
@@ -21,22 +22,24 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
                 {"minimumAllocationSize", "128"},
             }).Build();
 
+            var systemInterface = SystemInterface.GetInstance();
+
             allocators = new List<object[]>();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                allocators.Add(new object[] { new MacOSProtectedMemoryAllocatorLP64() });
+                allocators.Add(new object[] { new MacOSProtectedMemoryAllocatorLP64(systemInterface) });
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 if (LinuxOpenSSL11ProtectedMemoryAllocatorLP64.IsAvailable())
                 {
-                    allocators.Add(new object[] { new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration) });
+                    allocators.Add(new object[] { new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, systemInterface) });
                 }
-                allocators.Add(new object[] { new LinuxProtectedMemoryAllocatorLP64() });
+                allocators.Add(new object[] { new LinuxProtectedMemoryAllocatorLP64(systemInterface) });
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                allocators.Add(new object[] { new WindowsProtectedMemoryAllocatorVirtualAlloc(configuration) });
+                allocators.Add(new object[] { new WindowsProtectedMemoryAllocatorVirtualAlloc(configuration, systemInterface) });
             }
         }
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.PlatformNative.LP64.Libc;
 using GoDaddy.Asherah.PlatformNative.LP64.Linux;
 using GoDaddy.Asherah.PlatformNative.LP64.MacOS;
@@ -30,18 +31,19 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
             Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
+            var systemInterface = SystemInterface.GetInstance();
 
             Debug.WriteLine("LibcProtectedMemoryAllocatorTest ctor");
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 libc = new LinuxLibcLP64();
-                libcProtectedMemoryAllocator = new LinuxProtectedMemoryAllocatorLP64((LinuxLibcLP64)libc);
+                libcProtectedMemoryAllocator = new LinuxProtectedMemoryAllocatorLP64((LinuxLibcLP64)libc, systemInterface);
                 linuxProtectedMemoryAllocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 libc = new MacOSLibcLP64();
-                libcProtectedMemoryAllocator = new MacOSProtectedMemoryAllocatorLP64((MacOSLibcLP64)libc);
+                libcProtectedMemoryAllocator = new MacOSProtectedMemoryAllocatorLP64((MacOSLibcLP64)libc, systemInterface);
                 macOsProtectedMemoryAllocatorMock = new Mock<MacOSProtectedMemoryAllocatorLP64>() { CallBase = true };
             }
             else

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -143,6 +143,16 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
         }
 
         [SkippableFact]
+        private void TestHugeAllocShouldFail()
+        {
+            Skip.If(libc == null);
+
+            Debug.WriteLine("LibcProtectedMemoryAllocatorTest.TestHugeAllocShouldFail");
+
+            Assert.Throws<MemoryLimitException>(() => libcProtectedMemoryAllocator.Alloc((ulong)Int32.MaxValue + 1));
+        }
+
+        [SkippableFact]
         private void TestCheckPointerWithNullPointerShouldFail()
         {
             Skip.If(libc == null);

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
@@ -22,6 +22,8 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 
+            systemInterface = SystemInterface.GetInstance();
+
             configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
             {
                 {"heapSize", "32000"},

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
@@ -133,6 +133,31 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
         }
 
         [SkippableFact]
+        private void TestNullConfiguration()
+        {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+
+            Debug.WriteLine("\nTestNullConfiguration");
+
+            Assert.Throws<Exception>(() =>
+            {
+                linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(null, systemInterface);
+            });
+        }
+
+        [SkippableFact]
+        private void TestNullSystemInterface()
+        {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+
+            Debug.WriteLine("TestNullSystemInterface");
+            Assert.Throws<Exception>(() =>
+            {
+                linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, null);
+            });
+        }
+
+        [SkippableFact]
         private void TestAllocAfterDispose()
         {
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
@@ -139,7 +139,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
 
             Debug.WriteLine("\nTestNullConfiguration");
 
-            Assert.Throws<Exception>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(null, systemInterface);
             });
@@ -151,7 +151,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Debug.WriteLine("TestNullSystemInterface");
-            Assert.Throws<Exception>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
             {
                 linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, null);
             });

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux;
 using Microsoft.Extensions.Configuration;
 using Xunit;
@@ -13,6 +14,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
     {
         private LinuxOpenSSL11ProtectedMemoryAllocatorLP64 linuxOpenSSL11ProtectedMemoryAllocatorLP64;
         private IConfiguration configuration;
+        private readonly SystemInterface systemInterface;
 
         public LinuxOpenSSL11ProtectedMemoryAllocatorTest()
         {
@@ -29,8 +31,10 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
-                linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration);
+                linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, systemInterface);
             }
+
+            systemInterface = SystemInterface.GetInstance();
         }
 
         public void Dispose()
@@ -80,7 +84,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
 
-            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration);
+            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, systemInterface);
 
             linuxOpenSSL11ProtectedMemoryAllocatorLP64.Dispose();
 
@@ -98,7 +102,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
 
-            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration);
+            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, systemInterface);
 
             linuxOpenSSL11ProtectedMemoryAllocatorLP64.Dispose();
 
@@ -115,8 +119,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
-
-            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration);
+            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, systemInterface);
 
             linuxOpenSSL11ProtectedMemoryAllocatorLP64.Dispose();
 
@@ -134,7 +137,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
 
-            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration);
+            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, systemInterface);
 
             linuxOpenSSL11ProtectedMemoryAllocatorLP64.Dispose();
 
@@ -151,7 +154,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
 
             Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
-            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration);
+            linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, systemInterface);
 
             linuxOpenSSL11ProtectedMemoryAllocatorLP64.Dispose();
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux;
 using Xunit;
 
@@ -16,11 +17,12 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
             Trace.Listeners.Clear();
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
+            var systemInterface = SystemInterface.GetInstance();
 
             Debug.WriteLine("LinuxProtectedMemoryAllocatorTest ctor");
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                linuxProtectedMemoryAllocator = new LinuxProtectedMemoryAllocatorLP64();
+                linuxProtectedMemoryAllocator = new LinuxProtectedMemoryAllocatorLP64(systemInterface);
             }
         }
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/OpenSSLCryptProtectMemoryTests.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Linux/OpenSSLCryptProtectMemoryTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux;
 using Microsoft.Extensions.Configuration;
 using Xunit;
@@ -20,11 +21,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Linux
                 {"heapSize", "32000"},
                 {"minimumAllocationSize", "128"},
             }).Build();
-
+            var systemInterface = SystemInterface.GetInstance();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 Debug.WriteLine("\nLinuxOpenSSL11ProtectedMemoryAllocatorTest ctor");
-                linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration);
+                linuxOpenSSL11ProtectedMemoryAllocatorLP64 = new LinuxOpenSSL11ProtectedMemoryAllocatorLP64(configuration, systemInterface);
             }
         }
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemoryAllocatorTest.cs
@@ -34,7 +34,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             }).Build();
 
             Debug.WriteLine("ProtectedMemoryAllocatorTest ctor");
-            protectedMemoryAllocator = GetPlatformAllocator(configuration);
+            protectedMemoryAllocator = GetPlatformAllocator();
         }
 
         public void Dispose()
@@ -43,7 +43,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             protectedMemoryAllocator.Dispose();
         }
 
-        internal IProtectedMemoryAllocator GetPlatformAllocator(IConfiguration configuration)
+        internal IProtectedMemoryAllocator GetPlatformAllocator()
         {
             var systemInterface = SystemInterface.GetInstance();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -75,8 +75,8 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         [Fact]
         private void TestTwoAllocatorInstances()
         {
-            var allocator1 = GetPlatformAllocator(configuration);
-            var allocator2 = GetPlatformAllocator(configuration);
+            var allocator1 = GetPlatformAllocator();
+            var allocator2 = GetPlatformAllocator();
             Assert.NotNull(allocator1);
             Assert.NotNull(allocator2);
             allocator1.Dispose();

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemoryAllocatorTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux;
@@ -44,17 +45,18 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
 
         internal IProtectedMemoryAllocator GetPlatformAllocator(IConfiguration configuration)
         {
+            var systemInterface = SystemInterface.GetInstance();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                return new LinuxProtectedMemoryAllocatorLP64();
+                return new LinuxProtectedMemoryAllocatorLP64(systemInterface);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return new MacOSProtectedMemoryAllocatorLP64();
+                return new MacOSProtectedMemoryAllocatorLP64(systemInterface);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                return new WindowsProtectedMemoryAllocatorVirtualAlloc(configuration);
+                return new WindowsProtectedMemoryAllocatorVirtualAlloc(configuration, systemInterface);
             }
             else
             {

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
@@ -119,7 +119,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             var handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
             try
             {
-                Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestCreateSecretByteArray");
+                Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestCreateSecretIntPtr");
                 using (var factory = new ProtectedMemorySecretFactory(configuration))
                 {
                     using Secret secret = factory.CreateSecret(handle.AddrOfPinnedObject(), (ulong)bytes.LongLength);

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
@@ -177,5 +177,30 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
                 }
             }
         }
+
+        [Fact]
+        private void TestRequiredDisposeIntPtrSuccess()
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
+            {
+                {"requireSecretDisposal", "true"}
+            }).Build();
+
+            var bytes = new byte[] {0, 1};
+            var handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+            try
+            {
+                Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestRequiredDisposeIntPtrSuccess");
+                using (var factory = new ProtectedMemorySecretFactory(configuration))
+                {
+                    using Secret secret = factory.CreateSecret(handle.AddrOfPinnedObject(), (ulong)bytes.LongLength);
+                    Assert.Equal(typeof(ProtectedMemorySecret), secret.GetType());
+                }
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
     }
 }

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
@@ -113,6 +113,50 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         }
 
         [Fact]
+        private void TestCreateSecretIntPtr()
+        {
+            var bytes = new byte[] {0, 1};
+            var handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+            try
+            {
+                Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestCreateSecretByteArray");
+                using (var factory = new ProtectedMemorySecretFactory(configuration))
+                {
+                    using Secret secret = factory.CreateSecret(handle.AddrOfPinnedObject(), (ulong)bytes.LongLength);
+                    Assert.Equal(typeof(ProtectedMemorySecret), secret.GetType());
+                }
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        [Fact]
+        private void TestCreateSecretIntPtrZero()
+        {
+            var bytes = new byte[] { 0, 1 };
+            var handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
+            var ptr = IntPtr.Zero;
+            var len = 100;
+            try
+            {
+                Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestCreateSecretByteArray");
+                using (var factory = new ProtectedMemorySecretFactory(configuration))
+                {
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        using Secret secret = factory.CreateSecret(ptr, (ulong)len);
+                    });
+                }
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        [Fact]
         private void TestDoubleDispose()
         {
             var factory = new ProtectedMemorySecretFactory(configuration);
@@ -120,6 +164,18 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Assert.Throws<Exception>(() => {
                 factory.Dispose();
              });
+        }
+
+        [Fact]
+        private void TestMultipleRefCount()
+        {
+            using (var factory = new ProtectedMemorySecretFactory(configuration))
+            {
+                using (var factory2 = new ProtectedMemorySecretFactory(configuration))
+                {
+
+                }
+            }
         }
     }
 }

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -141,15 +141,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretUtf8CharsAction");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
-<<<<<<< HEAD
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
-=======
                 ProtectedMemorySecret.FromCharArray(
                     (char[])secretChars.Clone(),
                     protectedMemoryAllocator,
                     SystemInterface.GetInstance(),
                     configuration))
->>>>>>> 727d35d... Start moving allocators to SystemInterface
             {
                 secret.WithSecretUtf8Chars(decryptedChars =>
                 {
@@ -165,15 +161,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretUtf8CharsSuccess");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
-<<<<<<< HEAD
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
-=======
                 ProtectedMemorySecret.FromCharArray(
                     (char[])secretChars.Clone(),
                     protectedMemoryAllocator,
                     SystemInterface.GetInstance(),
                     configuration))
->>>>>>> 727d35d... Start moving allocators to SystemInterface
             {
                 secret.WithSecretUtf8Chars(decryptedChars =>
                 {

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.MacOS;
@@ -50,7 +51,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         private void TestNullConfiguration(IProtectedMemoryAllocator protectedMemoryAllocator)
         {
             Debug.WriteLine("TestNullConfiguration");
-            using (var secret = new ProtectedMemorySecret(new byte[] { 0, 1 }, protectedMemoryAllocator, null))
+            using (var secret = new ProtectedMemorySecret(
+                new byte[] { 0, 1 },
+                protectedMemoryAllocator,
+                SystemInterface.GetInstance(),
+                null))
             {
             }
         }
@@ -62,7 +67,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             protectedMemoryAllocatorMock.Setup(x => x.Alloc(It.IsAny<ulong>())).Returns(IntPtr.Zero);
             Assert.Throws<ProtectedMemoryAllocationFailedException>(() =>
             {
-                using (var secret = new ProtectedMemorySecret(new byte[] { 0, 1 }, protectedMemoryAllocatorMock.Object, configuration))
+                using (var secret = new ProtectedMemorySecret(
+                    new byte[] { 0, 1 },
+                    protectedMemoryAllocatorMock.Object,
+                    SystemInterface.GetInstance(),
+                    configuration))
                 {
                 }
             });
@@ -75,7 +84,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretBytesAction");
             byte[] secretBytes = { 0, 1 };
             using (ProtectedMemorySecret secret =
-                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator, configuration))
+                new ProtectedMemorySecret(
+                    (byte[])secretBytes.Clone(),
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration))
             {
                 secret.WithSecretBytes(decryptedBytes =>
                 {
@@ -91,7 +104,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretBytesSuccess");
             byte[] secretBytes = { 0, 1 };
             using (ProtectedMemorySecret secret =
-                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator, configuration))
+                new ProtectedMemorySecret(
+                    (byte[])secretBytes.Clone(),
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration))
             {
                 secret.WithSecretBytes(decryptedBytes =>
                 {
@@ -108,7 +125,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretBytesWithClosedSecretShouldFail");
             byte[] secretBytes = { 0, 1 };
             ProtectedMemorySecret secret =
-                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator, configuration);
+                new ProtectedMemorySecret(
+                    (byte[])secretBytes.Clone(),
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration);
             secret.Close();
             Assert.Throws<InvalidOperationException>(() => { secret.WithSecretBytes(decryptedBytes => true); });
         }
@@ -120,7 +141,15 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretUtf8CharsAction");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
+<<<<<<< HEAD
                 ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
+=======
+                ProtectedMemorySecret.FromCharArray(
+                    (char[])secretChars.Clone(),
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration))
+>>>>>>> 727d35d... Start moving allocators to SystemInterface
             {
                 secret.WithSecretUtf8Chars(decryptedChars =>
                 {
@@ -136,7 +165,15 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretUtf8CharsSuccess");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
+<<<<<<< HEAD
                 ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
+=======
+                ProtectedMemorySecret.FromCharArray(
+                    (char[])secretChars.Clone(),
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration))
+>>>>>>> 727d35d... Start moving allocators to SystemInterface
             {
                 secret.WithSecretUtf8Chars(decryptedChars =>
                 {
@@ -153,7 +190,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretIntPtrSuccess");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
+                ProtectedMemorySecret.FromCharArray(
+                    secretChars,
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration))
             {
                 secret.WithSecretIntPtr((ptr, len) =>
                 {
@@ -171,7 +212,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretIntPtrDisposed");
             char[] secretChars = { 'a', 'b' };
             ProtectedMemorySecret secret =
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration);
+                ProtectedMemorySecret.FromCharArray(
+                    secretChars,
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration);
 
             secret.Dispose();
             Assert.Throws<InvalidOperationException>(() =>
@@ -190,7 +235,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretIntPtrActionSuccess");
             char[] secretChars = { 'a', 'b' };
             using (ProtectedMemorySecret secret =
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration))
+                ProtectedMemorySecret.FromCharArray(
+                    secretChars,
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration))
             {
                 secret.WithSecretIntPtr((ptr, len) =>
                 {
@@ -207,7 +256,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestWithSecretUtf8CharsWithClosedSecretShouldFail");
             char[] secretChars = { 'a', 'b' };
             ProtectedMemorySecret secret =
-                ProtectedMemorySecret.FromCharArray(secretChars, protectedMemoryAllocator, configuration);
+                ProtectedMemorySecret.FromCharArray(
+                    secretChars,
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration);
             secret.Close();
             Assert.Throws<InvalidOperationException>(() => { secret.WithSecretUtf8Chars(decryptedChars => true); });
         }
@@ -219,7 +272,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Debug.WriteLine("TestCopySecret");
             byte[] secretBytes = { 0, 1 };
             using (ProtectedMemorySecret secret =
-                new ProtectedMemorySecret((byte[])secretBytes.Clone(), protectedMemoryAllocator, configuration))
+                new ProtectedMemorySecret(
+                    (byte[])secretBytes.Clone(),
+                    protectedMemoryAllocator,
+                    SystemInterface.GetInstance(),
+                    configuration))
             {
                 using (ProtectedMemorySecret secretCopy = (ProtectedMemorySecret)secret.CopySecret())
                 {
@@ -244,7 +301,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
                     new Mock<MacOSProtectedMemoryAllocatorLP64> { CallBase = true };
 
                 ProtectedMemorySecret secret =
-                    new ProtectedMemorySecret(secretBytes, protectedMemoryAllocatorMacOSMock.Object, configuration);
+                    new ProtectedMemorySecret(
+                        secretBytes,
+                        protectedMemoryAllocatorMacOSMock.Object,
+                        SystemInterface.GetInstance(),
+                        configuration);
                 secret.Close();
                 secret.Close();
                 protectedMemoryAllocatorMacOSMock.Verify(
@@ -256,7 +317,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
                     new Mock<LinuxProtectedMemoryAllocatorLP64> { CallBase = true };
 
                 ProtectedMemorySecret secret =
-                    new ProtectedMemorySecret(secretBytes, protectedMemoryAllocatorLinuxMock.Object, configuration);
+                    new ProtectedMemorySecret(
+                        secretBytes,
+                        protectedMemoryAllocatorLinuxMock.Object,
+                        SystemInterface.GetInstance(),
+                        configuration);
                 secret.Close();
                 secret.Close();
                 protectedMemoryAllocatorLinuxMock.Verify(
@@ -300,7 +365,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Assert.Throws<Exception>(() =>
             {
                 using ProtectedMemorySecret secret =
-                    new ProtectedMemorySecret(secretBytes, allocator, configuration);
+                    new ProtectedMemorySecret(
+                        secretBytes,
+                        allocator,
+                        SystemInterface.GetInstance(),
+                        configuration);
             });
         }
 
@@ -340,7 +409,11 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
             Assert.Throws<Exception>(() =>
             {
                 using ProtectedMemorySecret secret =
-                    new ProtectedMemorySecret(secretBytes, allocator, configuration);
+                    new ProtectedMemorySecret(
+                        secretBytes,
+                        allocator,
+                        SystemInterface.GetInstance(),
+                        configuration);
             });
         }
 

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Windows;
 using Microsoft.Extensions.Configuration;
 using Xunit;
@@ -19,6 +20,8 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Windows
             var consoleListener = new ConsoleTraceListener();
             Trace.Listeners.Add(consoleListener);
 
+            var systemInterface = SystemInterface.GetInstance();
+
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
             {
                 { "minimumWorkingSetSize", "33554430"},
@@ -27,7 +30,7 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Windows
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                windowsProtectedMemoryAllocator = new WindowsProtectedMemoryAllocatorVirtualAlloc(configuration);
+                windowsProtectedMemoryAllocator = new WindowsProtectedMemoryAllocatorVirtualAlloc(configuration, systemInterface);
             }
         }
 

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcOperationFailedException.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcOperationFailedException.cs
@@ -10,7 +10,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc
         }
 
         public LibcOperationFailedException(string methodName, long result, Exception exceptionInProgress)
-            : this(methodName, result, exceptionInProgress as object)
+            : base($"Libc call {methodName} failed with result {result}", exceptionInProgress)
         {
         }
 

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
@@ -22,14 +22,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc
             SystemInterface = systemInterface;
 
             libc.getrlimit(GetMemLockLimit(), out var rlim);
-            if (rlim.rlim_max == rlimit.UNLIMITED)
-            {
-                resourceLimit = 0;
-            }
-            else
-            {
-                resourceLimit = (long)rlim.rlim_max;
-            }
+            resourceLimit = rlim.rlim_max == rlimit.UNLIMITED ? 0 : (long) rlim.rlim_max;
         }
 
         protected SystemInterface SystemInterface { get; }

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
@@ -22,7 +22,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc
             SystemInterface = systemInterface;
 
             libc.getrlimit(GetMemLockLimit(), out var rlim);
-            resourceLimit = rlim.rlim_max == rlimit.UNLIMITED ? 0 : (long) rlim.rlim_max;
+            resourceLimit = rlim.rlim_max == rlimit.UNLIMITED ? 0 : (long)rlim.rlim_max;
         }
 
         protected SystemInterface SystemInterface { get; }

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
@@ -22,12 +22,30 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         public LinuxOpenSSL11ProtectedMemoryAllocatorLP64(IConfiguration configuration)
             : this(configuration, SystemInterface.GetInstance())
         {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
         }
 
         public LinuxOpenSSL11ProtectedMemoryAllocatorLP64(IConfiguration configuration, SystemInterface systemInterface)
             : base(new LinuxOpenSSL11LP64(), systemInterface)
         {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            if (systemInterface == null)
+            {
+                throw new ArgumentNullException(nameof(systemInterface));
+            }
+
             openSSL11 = (LinuxOpenSSL11LP64)GetLibc();
+            if (openSSL11 == null)
+            {
+                throw new InvalidOperationException("LinuxOpenSSL11ProtectedMemoryAllocatorLP64: GetLibc returned null!");
+            }
 
             ulong heapSize;
             var heapSizeConfig = configuration["heapSize"];

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
@@ -19,6 +19,11 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         private OpenSSLCryptProtectMemory cryptProtectMemory;
         private bool disposedValue;
 
+        public LinuxOpenSSL11ProtectedMemoryAllocatorLP64(IConfiguration configuration)
+            : this(configuration, SystemInterface.GetInstance())
+        {
+        }
+
         public LinuxOpenSSL11ProtectedMemoryAllocatorLP64(IConfiguration configuration, SystemInterface systemInterface)
             : base(new LinuxOpenSSL11LP64(), systemInterface)
         {

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
@@ -32,11 +32,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
                 throw new ArgumentNullException(nameof(configuration));
             }
 
-            if (systemInterface == null)
-            {
-                throw new ArgumentNullException(nameof(systemInterface));
-            }
-
             openSSL11 = (LinuxOpenSSL11LP64)GetLibc();
 
             ulong heapSize;

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
@@ -22,10 +22,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         public LinuxOpenSSL11ProtectedMemoryAllocatorLP64(IConfiguration configuration)
             : this(configuration, SystemInterface.GetInstance())
         {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
         }
 
         public LinuxOpenSSL11ProtectedMemoryAllocatorLP64(IConfiguration configuration, SystemInterface systemInterface)
@@ -42,10 +38,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
             }
 
             openSSL11 = (LinuxOpenSSL11LP64)GetLibc();
-            if (openSSL11 == null)
-            {
-                throw new InvalidOperationException("LinuxOpenSSL11ProtectedMemoryAllocatorLP64: GetLibc returned null!");
-            }
 
             ulong heapSize;
             var heapSizeConfig = configuration["heapSize"];

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.PlatformNative.LP64.Linux;
 using Microsoft.Extensions.Configuration;
 
@@ -18,8 +19,8 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         private OpenSSLCryptProtectMemory cryptProtectMemory;
         private bool disposedValue;
 
-        public LinuxOpenSSL11ProtectedMemoryAllocatorLP64(IConfiguration configuration)
-            : base(new LinuxOpenSSL11LP64())
+        public LinuxOpenSSL11ProtectedMemoryAllocatorLP64(IConfiguration configuration, SystemInterface systemInterface)
+            : base(new LinuxOpenSSL11LP64(), systemInterface)
         {
             openSSL11 = (LinuxOpenSSL11LP64)GetLibc();
 
@@ -183,11 +184,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
                     cryptProtectMemory.Dispose();
                 }
             }
-        }
-
-        protected override void ZeroMemory(IntPtr pointer, ulong length)
-        {
-            // CRYPTO_secure_clear_free includes ZeroMemory functionality
         }
     }
 }

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
@@ -26,7 +26,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         private readonly LinuxLibcLP64 libc;
 
         public LinuxProtectedMemoryAllocatorLP64()
-            : base(new LinuxLibcLP64(), SystemInterface.GetInstance())
+            : this(new LinuxLibcLP64(), SystemInterface.GetInstance())
         {
         }
 
@@ -35,12 +35,20 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         {
             Debug.WriteLine("LinuxProtectedMemoryAllocatorLP64 ctor");
             libc = (LinuxLibcLP64)GetLibc();
+            if (libc == null)
+            {
+                throw new InvalidOperationException("LinuxProtectedMemoryAllocatorLP64: GetLibc returned null");
+            }
         }
 
         public LinuxProtectedMemoryAllocatorLP64(LinuxLibcLP64 libc, SystemInterface systemInterface)
             : base(libc, systemInterface)
         {
-            this.libc = libc;
+            this.libc = libc ?? throw new ArgumentNullException(nameof(libc));
+            if (systemInterface == null)
+            {
+                throw new ArgumentNullException(nameof(libc));
+            }
         }
 
         public override void Dispose()

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.PlatformNative.LP64.Linux;
 using GoDaddy.Asherah.PlatformNative.LP64.Linux.Enums;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc;
@@ -24,15 +25,15 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         private readonly int pageSize = Environment.SystemPageSize;
         private readonly LinuxLibcLP64 libc;
 
-        public LinuxProtectedMemoryAllocatorLP64()
-            : base(new LinuxLibcLP64())
+        public LinuxProtectedMemoryAllocatorLP64(SystemInterface systemInterface)
+            : base(new LinuxLibcLP64(), systemInterface)
         {
             Debug.WriteLine("LinuxProtectedMemoryAllocatorLP64 ctor");
             libc = (LinuxLibcLP64)GetLibc();
         }
 
-        public LinuxProtectedMemoryAllocatorLP64(LinuxLibcLP64 libc)
-            : base(libc)
+        public LinuxProtectedMemoryAllocatorLP64(LinuxLibcLP64 libc, SystemInterface systemInterface)
+            : base(libc, systemInterface)
         {
             this.libc = libc;
         }
@@ -91,20 +92,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         internal override int GetMemLockLimit()
         {
             return (int)RlimitResource.RLIMIT_MEMLOCK;
-        }
-
-        // Platform specific zero memory
-        protected override void ZeroMemory(IntPtr pointer, ulong length)
-        {
-            Check.IntPtr(pointer, "ZeroMemory");
-            if (length < 1)
-            {
-                throw new Exception("ZeroMemory: Invalid length");
-            }
-
-            // Glibc bzero doesn't seem to be vulnerable to being optimized away
-            // Glibc doesn't seem to have explicit_bzero, memset_s, or memset_explicit
-            libc.bzero(pointer, length);
         }
     }
 }

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
@@ -35,16 +35,12 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         {
             Debug.WriteLine("LinuxProtectedMemoryAllocatorLP64 ctor");
             libc = (LinuxLibcLP64)GetLibc();
-            if (libc == null)
-            {
-                throw new InvalidOperationException("LinuxProtectedMemoryAllocatorLP64: GetLibc returned null");
-            }
         }
 
         public LinuxProtectedMemoryAllocatorLP64(LinuxLibcLP64 libc, SystemInterface systemInterface)
             : base(libc, systemInterface)
         {
-            this.libc = libc ?? throw new ArgumentNullException(nameof(libc));
+            this.libc = libc;
             if (systemInterface == null)
             {
                 throw new ArgumentNullException(nameof(systemInterface));

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
@@ -25,6 +25,11 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         private readonly int pageSize = Environment.SystemPageSize;
         private readonly LinuxLibcLP64 libc;
 
+        public LinuxProtectedMemoryAllocatorLP64()
+            : base(new LinuxLibcLP64(), SystemInterface.GetInstance())
+        {
+        }
+
         public LinuxProtectedMemoryAllocatorLP64(SystemInterface systemInterface)
             : base(new LinuxLibcLP64(), systemInterface)
         {

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxProtectedMemoryAllocatorLP64.cs
@@ -47,7 +47,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
             this.libc = libc ?? throw new ArgumentNullException(nameof(libc));
             if (systemInterface == null)
             {
-                throw new ArgumentNullException(nameof(libc));
+                throw new ArgumentNullException(nameof(systemInterface));
             }
         }
 

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/OpenSSLCryptProtectMemory.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/OpenSSLCryptProtectMemory.cs
@@ -11,11 +11,11 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
     {
         private readonly ulong pageSize = (ulong)Environment.SystemPageSize;
         private OpenSSLCrypto openSSLCrypto;
-        private IntPtr encryptCtx = IntPtr.Zero;
-        private IntPtr decryptCtx = IntPtr.Zero;
-        private IntPtr evpCipher = IntPtr.Zero;
-        private IntPtr key = IntPtr.Zero;
-        private IntPtr iv = IntPtr.Zero;
+        private IntPtr encryptCtx;
+        private IntPtr decryptCtx;
+        private IntPtr evpCipher;
+        private IntPtr key;
+        private IntPtr iv;
         private int blockSize;
         private bool disposedValue;
         private LinuxOpenSSL11LP64 openSSL11;
@@ -207,7 +207,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
         {
             if (!disposedValue)
             {
-                LinuxOpenSSL11LP64 openSSL11ref = null;
+                LinuxOpenSSL11LP64 openSSL11ref;
                 try
                 {
                     if (disposing)

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/MacOS/MacOSProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/MacOS/MacOSProtectedMemoryAllocatorLP64.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.PlatformNative.LP64.MacOS;
 using GoDaddy.Asherah.PlatformNative.LP64.MacOS.Enums;
 using GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc;
@@ -22,15 +23,15 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.MacOS
     {
         private readonly MacOSLibcLP64 libc;
 
-        public MacOSProtectedMemoryAllocatorLP64()
-            : base(new MacOSLibcLP64())
+        public MacOSProtectedMemoryAllocatorLP64(SystemInterface systemInterface)
+            : base(new MacOSLibcLP64(), systemInterface)
         {
             libc = (MacOSLibcLP64)GetLibc();
             DisableCoreDumpGlobally();
         }
 
-        public MacOSProtectedMemoryAllocatorLP64(MacOSLibcLP64 libc)
-            : base(libc)
+        public MacOSProtectedMemoryAllocatorLP64(MacOSLibcLP64 libc, SystemInterface systemInterface)
+            : base(libc, systemInterface)
         {
             this.libc = libc;
         }
@@ -82,13 +83,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.MacOS
         internal override int GetMemLockLimit()
         {
             return (int)RlimitResource.RLIMIT_MEMLOCK;
-        }
-
-        protected override void ZeroMemory(IntPtr pointer, ulong length)
-        {
-            // This differs on different platforms
-            // MacOS has memset_s which is standardized and secure
-            libc.memset_s(pointer, length, 0, length);
         }
     }
 }

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/MacOS/MacOSProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/MacOS/MacOSProtectedMemoryAllocatorLP64.cs
@@ -21,6 +21,11 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.MacOS
 
     internal class MacOSProtectedMemoryAllocatorLP64 : LibcProtectedMemoryAllocatorLP64
     {
+        public MacOSProtectedMemoryAllocatorLP64()
+            : base(new MacOSLibcLP64(), SystemInterface.GetInstance())
+        {
+        }
+
         public MacOSProtectedMemoryAllocatorLP64(SystemInterface systemInterface)
             : base(new MacOSLibcLP64(), systemInterface)
         {

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/MacOS/MacOSProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/MacOS/MacOSProtectedMemoryAllocatorLP64.cs
@@ -21,19 +21,15 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.MacOS
 
     internal class MacOSProtectedMemoryAllocatorLP64 : LibcProtectedMemoryAllocatorLP64
     {
-        private readonly MacOSLibcLP64 libc;
-
         public MacOSProtectedMemoryAllocatorLP64(SystemInterface systemInterface)
             : base(new MacOSLibcLP64(), systemInterface)
         {
-            libc = (MacOSLibcLP64)GetLibc();
             DisableCoreDumpGlobally();
         }
 
         public MacOSProtectedMemoryAllocatorLP64(MacOSLibcLP64 libc, SystemInterface systemInterface)
             : base(libc, systemInterface)
         {
-            this.libc = libc;
         }
 
         public override void Dispose()

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/MacOS/MacOSProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/MacOS/MacOSProtectedMemoryAllocatorLP64.cs
@@ -35,6 +35,10 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.MacOS
         public MacOSProtectedMemoryAllocatorLP64(MacOSLibcLP64 libc, SystemInterface systemInterface)
             : base(libc, systemInterface)
         {
+            if (libc == null)
+            {
+                throw new ArgumentNullException(nameof(libc));
+            }
         }
 
         public override void Dispose()

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
@@ -34,7 +34,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
             SystemInterface systemInterface,
             IConfiguration configuration)
         {
-            Debug.WriteLine("ProtectedMemorySecret ctor");
+            Debug.WriteLine("ProtectedMemorySecret ctor IntPtr");
 
             if (sourcePtr == IntPtr.Zero)
             {
@@ -89,9 +89,6 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
 
                 throw;
             }
-
-            // Only clear the client's source buffer if we're successful
-            systemInterface.ZeroMemory(pointer, length);
         }
 
         internal ProtectedMemorySecret(

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using GoDaddy.Asherah.PlatformNative;
 using Microsoft.Extensions.Configuration;
 
 [assembly: InternalsVisibleTo("SecureMemory.Tests")]
@@ -18,18 +19,85 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
         private readonly IProtectedMemoryAllocator allocator;
         private readonly IConfiguration configuration;
         private readonly bool requireSecretDisposal;
+        private readonly SystemInterface systemInterface;
+        private readonly string creationStackTrace;
         private IntPtr pointer;
-        private string creationStackTrace;
 
         // IMPORTANT: accessCounter is not volatile nor atomic since we use accessLock for all read and write
         // access. If that changes, update the counter accordingly!
         private long accessCounter = 0;
 
-        internal ProtectedMemorySecret(byte[] sourceBytes, IProtectedMemoryAllocator allocator, IConfiguration configuration)
+        internal ProtectedMemorySecret(
+            IntPtr sourcePtr,
+            ulong length,
+            IProtectedMemoryAllocator allocator,
+            SystemInterface systemInterface,
+            IConfiguration configuration)
         {
             Debug.WriteLine("ProtectedMemorySecret ctor");
             this.allocator = allocator;
             this.configuration = configuration;
+            this.systemInterface = systemInterface;
+
+            if (configuration != null)
+            {
+#if !DEBUG
+                if (configuration["debugSecrets"] == "true")
+                {
+                    creationStackTrace = Environment.StackTrace;
+                }
+#else
+                creationStackTrace = Environment.StackTrace;
+#endif
+
+                if (configuration["requireSecretDisposal"] == "true")
+                {
+                    requireSecretDisposal = true;
+                }
+            }
+
+            this.length = length;
+            pointer = this.allocator.Alloc(length);
+
+            if (pointer == IntPtr.Zero)
+            {
+                throw new ProtectedMemoryAllocationFailedException("Protected memory allocation failed");
+            }
+
+            try
+            {
+                systemInterface.CopyMemory(sourcePtr, pointer, length);
+                this.allocator.SetNoAccess(pointer, length);
+            }
+            catch
+            {
+                try
+                {
+                    this.allocator.SetReadWriteAccess(pointer, length);
+                }
+                finally
+                {
+                    this.allocator.Free(pointer, length);
+                    pointer = IntPtr.Zero;
+                }
+
+                throw;
+            }
+
+            // Only clear the client's source buffer if we're successful
+            systemInterface.ZeroMemory(pointer, length);
+        }
+
+        internal ProtectedMemorySecret(
+            byte[] sourceBytes,
+            IProtectedMemoryAllocator allocator,
+            SystemInterface systemInterface,
+            IConfiguration configuration)
+        {
+            Debug.WriteLine("ProtectedMemorySecret ctor");
+            this.allocator = allocator;
+            this.configuration = configuration;
+            this.systemInterface = systemInterface;
 
             if (configuration != null)
             {
@@ -173,7 +241,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
         public override Secret CopySecret()
         {
             Debug.WriteLine("ProtectedMemorySecret.CopySecret");
-            return WithSecretBytes(bytes => new ProtectedMemorySecret(bytes, allocator, configuration));
+            return WithSecretBytes(bytes => new ProtectedMemorySecret(bytes, allocator, systemInterface, configuration));
         }
 
         public override void Close()
@@ -190,12 +258,16 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
             GC.SuppressFinalize(this);
         }
 
-        internal static ProtectedMemorySecret FromCharArray(char[] sourceChars, IProtectedMemoryAllocator allocator, IConfiguration configuration)
+        internal static ProtectedMemorySecret FromCharArray(
+            char[] sourceChars,
+            IProtectedMemoryAllocator allocator,
+            SystemInterface systemInterface,
+            IConfiguration configuration)
         {
             byte[] sourceBytes = Encoding.UTF8.GetBytes(sourceChars);
             try
             {
-                return new ProtectedMemorySecret(sourceBytes, allocator, configuration);
+                return new ProtectedMemorySecret(sourceBytes, allocator, systemInterface, configuration);
             }
             finally
             {
@@ -215,11 +287,11 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                 if (requireSecretDisposal)
                 {
                     const string exceptionMessage = "FATAL: Reached finalizer for ProtectedMemorySecret (missing Dispose())";
-                    throw new Exception(exceptionMessage + ((creationStackTrace == null) ? string.Empty : Environment.NewLine + creationStackTrace));
+                    throw new Exception(exceptionMessage + (creationStackTrace == null ? string.Empty : Environment.NewLine + creationStackTrace));
                 }
 
                 const string warningMessage = "WARN: Reached finalizer for ProtectedMemorySecret (missing Dispose())";
-                Debug.WriteLine(warningMessage + ((creationStackTrace == null) ? string.Empty : Environment.NewLine + creationStackTrace));
+                Debug.WriteLine(warningMessage + (creationStackTrace == null ? string.Empty : Environment.NewLine + creationStackTrace));
             }
             else
             {

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecret.cs
@@ -35,6 +35,12 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
             IConfiguration configuration)
         {
             Debug.WriteLine("ProtectedMemorySecret ctor");
+
+            if (sourcePtr == IntPtr.Zero)
+            {
+                throw new ArgumentNullException(nameof(sourcePtr));
+            }
+
             this.allocator = allocator;
             this.configuration = configuration;
             this.systemInterface = systemInterface;

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
@@ -135,7 +135,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                     case Architecture.Arm:
                         throw new PlatformNotSupportedException("Unsupported architecture Linux ARM");
                     default:
-                        throw new ArgumentOutOfRangeException("Unknown OSArchitecture");
+                        throw new PlatformNotSupportedException("Unknown OSArchitecture");
                 }
             }
 
@@ -156,7 +156,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                     case Architecture.Arm:
                         throw new PlatformNotSupportedException("Unsupported architecture macOS ARM");
                     default:
-                        throw new ArgumentOutOfRangeException("Unknown OSArchitecture");
+                        throw new PlatformNotSupportedException("Unknown OSArchitecture");
                 }
             }
 

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
@@ -34,7 +34,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                 }
 
                 allocator = DetectViaRuntimeInformation(configuration)
-                         ?? DetectViaOsVersionPlatform(configuration)
+                         ?? DetectViaOsVersionPlatform()
                          ?? DetectOsDescription(configuration);
 
                 if (allocator == null)
@@ -92,7 +92,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
         }
 
         [ExcludeFromCodeCoverage]
-        private static IProtectedMemoryAllocator DetectViaOsVersionPlatform(IConfiguration configuration)
+        private static IProtectedMemoryAllocator DetectViaOsVersionPlatform()
         {
             switch (Environment.OSVersion.Platform)
             {

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
@@ -33,14 +33,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                     return;
                 }
 
-                allocator = DetectViaRuntimeInformation(configuration)
-                         ?? DetectViaOsVersionPlatform()
-                         ?? DetectOsDescription(configuration);
-
-                if (allocator == null)
-                {
-                    throw new PlatformNotSupportedException("Could not detect supported platform for protected memory");
-                }
+                allocator = DetectAllocator(configuration);
 
                 Debug.WriteLine("ProtectedMemorySecretFactory: Created new allocator");
                 refCount++;
@@ -89,6 +82,21 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                     Debug.WriteLine($"ProtectedMemorySecretFactory: New refCount is {refCount}");
                 }
             }
+        }
+
+        [ExcludeFromCodeCoverage]
+        private static IProtectedMemoryAllocator DetectAllocator(IConfiguration configuration)
+        {
+            var platformAllocator = DetectViaRuntimeInformation(configuration)
+                        ?? DetectViaOsVersionPlatform()
+                        ?? DetectOsDescription(configuration);
+
+            if (platformAllocator == null)
+            {
+                throw new PlatformNotSupportedException("Could not detect supported platform for protected memory");
+            }
+
+            return platformAllocator;
         }
 
         [ExcludeFromCodeCoverage]

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorLLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorLLP64.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.PlatformNative.LLP64.Windows;
 using GoDaddy.Asherah.PlatformNative.LLP64.Windows.Enums;
 
@@ -8,6 +9,13 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Windows
     internal abstract class WindowsProtectedMemoryAllocatorLLP64 : IProtectedMemoryAllocator
     {
         protected static readonly IntPtr InvalidPointer = new IntPtr(-1);
+
+        protected WindowsProtectedMemoryAllocatorLLP64(SystemInterface systemInterface)
+        {
+            SystemInterface = systemInterface;
+        }
+
+        protected SystemInterface SystemInterface { get; }
 
         public abstract IntPtr Alloc(ulong length);
 
@@ -54,7 +62,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Windows
 
         public void ZeroMemory(IntPtr pointer, ulong length)
         {
-            WindowsInterop.ZeroMemory(pointer, (UIntPtr)length);
+            SystemInterface.ZeroMemory(pointer, length);
         }
 
         public void Dispose()

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorVirtualAlloc.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Windows/WindowsProtectedMemoryAllocatorVirtualAlloc.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using GoDaddy.Asherah.PlatformNative;
 using GoDaddy.Asherah.PlatformNative.LLP64.Windows;
 using GoDaddy.Asherah.PlatformNative.LLP64.Windows.Enums;
 using Microsoft.Extensions.Configuration;
@@ -11,7 +12,8 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Windows
         private const int DefaultMaximumWorkingSetSize = 67108860;
         private const int DefaultMinimumWorkingSetSize = 33554430;
 
-        public WindowsProtectedMemoryAllocatorVirtualAlloc(IConfiguration configuration)
+        public WindowsProtectedMemoryAllocatorVirtualAlloc(IConfiguration configuration, SystemInterface systemInterface)
+            : base(systemInterface)
         {
             UIntPtr min = UIntPtr.Zero;
             UIntPtr max = UIntPtr.Zero;
@@ -71,8 +73,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Windows
 
         public override void Free(IntPtr pointer, ulong length)
         {
-            WindowsInterop.ZeroMemory(pointer, (UIntPtr)length);
-
+            SystemInterface.ZeroMemory(pointer, length);
             if (!WindowsInterop.VirtualFree(pointer, UIntPtr.Zero, AllocationType.RELEASE))
             {
                 var errno = Marshal.GetLastWin32Error();

--- a/csharp/SecureMemory/SecureMemory/Secret.cs
+++ b/csharp/SecureMemory/SecureMemory/Secret.cs
@@ -1,5 +1,4 @@
 using System;
-using System.ComponentModel;
 
 namespace GoDaddy.Asherah.SecureMemory
 {

--- a/csharp/SecureMemory/SecureMemory/Secret.cs
+++ b/csharp/SecureMemory/SecureMemory/Secret.cs
@@ -10,7 +10,7 @@ namespace GoDaddy.Asherah.SecureMemory
 
         public abstract TResult WithSecretIntPtr<TResult>(Func<IntPtr, ulong, TResult> funcWithSecret);
 
-        public void WithSecretBytes(Action<byte[]> actionWithSecret)
+        public virtual void WithSecretBytes(Action<byte[]> actionWithSecret)
         {
             WithSecretBytes(bytes =>
             {
@@ -19,7 +19,7 @@ namespace GoDaddy.Asherah.SecureMemory
             });
         }
 
-        public void WithSecretUtf8Chars(Action<char[]> actionWithSecret)
+        public virtual void WithSecretUtf8Chars(Action<char[]> actionWithSecret)
         {
             WithSecretUtf8Chars(chars =>
             {
@@ -28,7 +28,7 @@ namespace GoDaddy.Asherah.SecureMemory
             });
         }
 
-        public void WithSecretIntPtr(Action<IntPtr, ulong> actionWithSecret)
+        public virtual void WithSecretIntPtr(Action<IntPtr, ulong> actionWithSecret)
         {
             WithSecretIntPtr((ptr, len) =>
             {

--- a/csharp/SecureMemory/SecureMemory/Secret.cs
+++ b/csharp/SecureMemory/SecureMemory/Secret.cs
@@ -10,7 +10,7 @@ namespace GoDaddy.Asherah.SecureMemory
 
         public abstract TResult WithSecretIntPtr<TResult>(Func<IntPtr, ulong, TResult> funcWithSecret);
 
-        public virtual void WithSecretBytes(Action<byte[]> actionWithSecret)
+        public void WithSecretBytes(Action<byte[]> actionWithSecret)
         {
             WithSecretBytes(bytes =>
             {
@@ -19,7 +19,7 @@ namespace GoDaddy.Asherah.SecureMemory
             });
         }
 
-        public virtual void WithSecretUtf8Chars(Action<char[]> actionWithSecret)
+        public void WithSecretUtf8Chars(Action<char[]> actionWithSecret)
         {
             WithSecretUtf8Chars(chars =>
             {
@@ -28,7 +28,7 @@ namespace GoDaddy.Asherah.SecureMemory
             });
         }
 
-        public virtual void WithSecretIntPtr(Action<IntPtr, ulong> actionWithSecret)
+        public void WithSecretIntPtr(Action<IntPtr, ulong> actionWithSecret)
         {
             WithSecretIntPtr((ptr, len) =>
             {


### PR DESCRIPTION
This contains the extension of IntPtr functionality into ProtectedMemorySecret to enable keeping secret keys entirely in unmanaged memory in upcoming OpenSSL-phase3