### PR TITLE
Set DateParseHandling to None

### DIFF
--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Util/JsonTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Util/JsonTest.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Text;
 using LanguageExt;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -13,6 +15,26 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Util
         public JsonTest()
         {
             testDocument = new Asherah.AppEncryption.Util.Json();
+        }
+
+        [Fact]
+        public void TestJsonDateParsing()
+        {
+            string time = DateTime.UtcNow.ToString("o");
+            JObject jObject = new JObject
+            {
+                { "Created", 1541461380 },
+                { "Time", time },
+            };
+
+            // Get json bytes
+            byte[] jsonBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(jObject));
+
+            // Convert to JObject using the Asherah.AppEncryption.Util.Json class. This in turn calls the
+            // ConvertUtf8ToJson method which sets the DateParseHandling to None
+            JObject json = new Asherah.AppEncryption.Util.Json(jsonBytes).ToJObject();
+
+            Assert.Equal(time, json.GetValue("Time").ToString());
         }
 
         [Fact]
@@ -32,7 +54,8 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Util
         private void TestGetDateTimeOffsetWithDateTimeKindLocal()
         {
             string key = "testDateTime";
-            DateTimeOffset expectedDateTime = new DateTimeOffset(new DateTime(2019, 3, 21, 23, 24, 0, DateTimeKind.Local));
+            DateTimeOffset expectedDateTime =
+                new DateTimeOffset(new DateTime(2019, 3, 21, 23, 24, 0, DateTimeKind.Local));
 
             testDocument.Put(key, expectedDateTime);
             DateTimeOffset actualDateTime = testDocument.GetDateTimeOffset(key);
@@ -44,7 +67,8 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Util
         private void TestGetDateTimeOffsetWithDateTimeKindUnspecified()
         {
             string key = "testDateTime";
-            DateTimeOffset expectedDateTime = new DateTimeOffset(new DateTime(2019, 3, 21, 23, 24, 0, DateTimeKind.Unspecified));
+            DateTimeOffset expectedDateTime =
+                new DateTimeOffset(new DateTime(2019, 3, 21, 23, 24, 0, DateTimeKind.Unspecified));
 
             testDocument.Put(key, expectedDateTime);
             DateTimeOffset actualDateTime = testDocument.GetDateTimeOffset(key);
@@ -57,7 +81,8 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Util
         {
             string key = "testDateTime";
 
-            DateTimeOffset expectedDateTime = new DateTimeOffset(new DateTime(2019, 3, 21, 23, 24, 0, DateTimeKind.Utc));
+            DateTimeOffset expectedDateTime =
+                new DateTimeOffset(new DateTime(2019, 3, 21, 23, 24, 0, DateTimeKind.Utc));
 
             testDocument.Put(key, expectedDateTime);
             DateTimeOffset actualDateTime = testDocument.GetDateTimeOffset(key);

--- a/csharp/AppEncryption/AppEncryption/Util/Json.cs
+++ b/csharp/AppEncryption/AppEncryption/Util/Json.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
-using App.Metrics.Timer;
 using LanguageExt;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -19,7 +17,6 @@ namespace GoDaddy.Asherah.AppEncryption.Util
     /// </summary>
     public class Json
     {
-        private static readonly TimerOptions JsonTimerOptions = new TimerOptions { Name = MetricsUtil.AelMetricsPrefix + ".json.ConvertUtf8ToJson" };
         private readonly JObject document;
 
         /// <summary>

--- a/csharp/AppEncryption/AppEncryption/Util/Json.cs
+++ b/csharp/AppEncryption/AppEncryption/Util/Json.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
+using App.Metrics.Timer;
 using LanguageExt;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -16,6 +19,7 @@ namespace GoDaddy.Asherah.AppEncryption.Util
     /// </summary>
     public class Json
     {
+        private static readonly TimerOptions JsonTimerOptions = new TimerOptions { Name = MetricsUtil.AelMetricsPrefix + ".json.ConvertUtf8ToJson" };
         private readonly JObject document;
 
         /// <summary>
@@ -244,10 +248,10 @@ namespace GoDaddy.Asherah.AppEncryption.Util
 
         private static JObject ConvertUtf8ToJson(byte[] utf8)
         {
-            string bytesAsString = Encoding.UTF8.GetString(utf8);
+            JsonReader jsonReader = new JsonTextReader(new StreamReader(new MemoryStream(utf8), Encoding.UTF8));
+            jsonReader.DateParseHandling = DateParseHandling.None;
 
-            // JObject.Parse appears to be more efficient than JsonConvert.DeserializeObject
-            return JObject.Parse(bytesAsString);
+            return JObject.Load(jsonReader);
         }
     }
 }

--- a/csharp/AppEncryption/Directory.Build.props
+++ b/csharp/AppEncryption/Directory.Build.props
@@ -3,4 +3,3 @@
     <Version>0.1.6</Version>
   </PropertyGroup>
 </Project>
-

--- a/csharp/AppEncryption/Directory.Build.props
+++ b/csharp/AppEncryption/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.6-alpha</Version>
+    <Version>0.1.6</Version>
   </PropertyGroup>
 </Project>
+

--- a/docs/SystemRequirements.md
+++ b/docs/SystemRequirements.md
@@ -121,4 +121,4 @@ spec:
       capabilities:
         add: ["IPC_LOCK"]
   restartPolicy: Never
-```  
+```


### PR DESCRIPTION
- When retrieving data from a JSON blob, Newtonsoft.Json attempts to parse any data that looks like dates internally as a DateTime. As a result of this, when a date time value is pulled as a string, it uses its own default formatting to make the value different from how it originally was.
To avoid this, we are explicitly setting DateParseHandling to None.
- Bump version for release