### PR TITLE
[C#] Fix handling of very large/unlimited memlock rlimit

### DIFF
--- a/csharp/SecureMemory/Directory.Build.props
+++ b/csharp/SecureMemory/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.1.10</Version>
+    <Version>0.1.11</Version>
   </PropertyGroup>
 </Project>

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -85,6 +85,45 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
         }
 
         [SkippableFact]
+        private void TestAlocWithResourceLimitZero()
+        {
+            Skip.If(libc == null);
+
+            var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
+            allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(0);
+
+            var allocator = allocatorMock.Object;
+            Assert.Throws<MemoryLimitException>(() =>
+            {
+                allocator.Alloc(1);
+            });
+        }
+
+        [SkippableFact]
+        private void TestAlocWithResourceLimitMaxValue()
+        {
+            Skip.If(libc == null);
+
+            var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
+            allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(ulong.MaxValue);
+
+            var allocator = allocatorMock.Object;
+            allocator.Alloc(1);
+        }
+
+        [SkippableFact]
+        private void TestAlocWithResourceLimitLargeValue()
+        {
+            Skip.If(libc == null);
+
+            var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
+            allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(ulong.MaxValue-1);
+
+            var allocator = allocatorMock.Object;
+            allocator.Alloc(1);
+        }
+
+        [SkippableFact]
         private void TestAllocWithSetNoDumpErrorShouldFail()
         {
             Skip.If(libc == null);

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
@@ -18,15 +18,14 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc
         protected LibcProtectedMemoryAllocatorLP64(LibcLP64 libc)
         {
             this.libc = libc ?? throw new ArgumentNullException(nameof(libc));
-
-            libc.getrlimit(GetMemLockLimit(), out var rlim);
-            if (rlim.rlim_max == rlimit.UNLIMITED)
+            var rlim = GetMemlockResourceLimit();
+            if (rlim == rlimit.UNLIMITED || rlim > long.MaxValue)
             {
-                resourceLimit = 0;
+                resourceLimit = long.MaxValue;
             }
             else
             {
-                resourceLimit = (long)rlim.rlim_max;
+                resourceLimit = (long)rlim;
             }
         }
 
@@ -151,6 +150,12 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc
         internal abstract int GetPrivateAnonymousFlags();
 
         internal abstract int GetMemLockLimit();
+
+        internal virtual ulong GetMemlockResourceLimit()
+        {
+            libc.getrlimit(GetMemLockLimit(), out var rlim);
+            return rlim.rlim_max;
+        }
 
         protected abstract void ZeroMemory(IntPtr pointer, ulong length);
 


### PR DESCRIPTION
The previous implementation suffered from two issues:
- an rlimit of unlimited was managed internally as a resource limit of 0,
  leading to a MemoryLimitException on subsequent Alloc() calls.
- an rlimit > long.MaxValue resulted in an overflow condition and a resource
  limit of less than 0, also leading to a MemoryLimitExeption.

Resolves #358 