### PR TITLE
Fix cross-region decryption bug in Java and C#

### DIFF
--- a/csharp/AppEncryption/AppEncryption.IntegrationTests/Regression/DynamoDbGlobalTableTest.cs
+++ b/csharp/AppEncryption/AppEncryption.IntegrationTests/Regression/DynamoDbGlobalTableTest.cs
@@ -16,10 +16,10 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
         private const string PartitionKey = "Id";
         private const string SortKey = "Created";
         private const string DefaultTableName = "EncryptionKey";
+        private const string DefaultRegion = "us-west-2";
+        private const string DynamoDbPort = "8000";
 
         private readonly ConfigFixture configFixture;
-        private readonly DynamoDbMetastoreImpl dynamoDbMetastoreImpl;
-        private readonly DynamoDbMetastoreImpl dynamoDbMetastoreImplWithKeySuffix;
 
         private IAmazonDynamoDB tempDynamoDbClient;
 
@@ -50,17 +50,6 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
                 ProvisionedThroughput = new ProvisionedThroughput(1L, 1L),
             };
             tempDynamoDbClient.CreateTableAsync(request).Wait();
-
-            // Use a builder without the suffix
-            dynamoDbMetastoreImpl = DynamoDbMetastoreImpl.NewBuilder("us-west-2")
-                .WithEndPointConfiguration(dynamoDbContainerFixture.ServiceUrl, "us-west-2")
-                .Build();
-
-            // Connect to the same metastore but initialize it with a key suffix
-            dynamoDbMetastoreImplWithKeySuffix = DynamoDbMetastoreImpl.NewBuilder("us-west-2")
-                .WithEndPointConfiguration(dynamoDbContainerFixture.ServiceUrl, "us-west-2")
-                .WithKeySuffix()
-                .Build();
         }
 
         public void Dispose()
@@ -68,7 +57,7 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
             try
             {
                 DeleteTableResponse deleteTableResponse = tempDynamoDbClient
-                    .DeleteTableAsync(dynamoDbMetastoreImpl.TableName)
+                    .DeleteTableAsync(DefaultTableName)
                     .Result;
             }
             catch (AggregateException)
@@ -76,6 +65,20 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
                 // There is no such table.
             }
         }
+
+        private SessionFactory GetSessionFactory(bool withKeySuffix, string region)
+        {
+        DynamoDbMetastoreImpl.IBuildStep builder = DynamoDbMetastoreImpl.NewBuilder(region)
+          .WithEndPointConfiguration("http://localhost:" + DynamoDbPort, "us-west-2");
+
+        if (withKeySuffix)
+        {
+          builder = builder.WithKeySuffix();
+        }
+
+        DynamoDbMetastoreImpl dynamoDbMetastore = builder.Build();
+        return SessionFactoryGenerator.CreateDefaultSessionFactory(configFixture.KeyManagementService, dynamoDbMetastore);
+      }
 
         [Fact]
         private void TestRegionSuffix()
@@ -85,8 +88,7 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
             byte[] dataRowRecordBytes;
 
             // Encrypt originalPayloadString with metastore with key suffix
-            using (SessionFactory sessionFactory = SessionFactoryGenerator
-                .CreateDefaultSessionFactory(configFixture.KeyManagementService, dynamoDbMetastoreImplWithKeySuffix))
+            using (SessionFactory sessionFactory = GetSessionFactory(true, DefaultRegion))
             {
                 using (Session<byte[], byte[]> sessionBytes = sessionFactory.GetSessionBytes("shopper123"))
                 {
@@ -95,8 +97,7 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
             }
 
             // Decrypt dataRowString with metastore with key suffix
-            using (SessionFactory sessionFactory = SessionFactoryGenerator
-                .CreateDefaultSessionFactory(configFixture.KeyManagementService, dynamoDbMetastoreImplWithKeySuffix))
+            using (SessionFactory sessionFactory = GetSessionFactory(true, DefaultRegion))
             {
                 using (Session<byte[], byte[]> sessionBytes = sessionFactory.GetSessionBytes("shopper123"))
                 {
@@ -117,8 +118,7 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
             byte[] dataRowRecordBytes;
 
             // Encrypt originalPayloadString with metastore without key suffix
-            using (SessionFactory sessionFactory = SessionFactoryGenerator
-                .CreateDefaultSessionFactory(configFixture.KeyManagementService, dynamoDbMetastoreImpl))
+            using (SessionFactory sessionFactory = GetSessionFactory(false, DefaultRegion))
             {
                 using (Session<byte[], byte[]> sessionBytes = sessionFactory.GetSessionBytes("shopper123"))
                 {
@@ -127,8 +127,37 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
             }
 
             // Decrypt dataRowString with metastore with key suffix
-            using (SessionFactory sessionFactory = SessionFactoryGenerator
-                .CreateDefaultSessionFactory(configFixture.KeyManagementService, dynamoDbMetastoreImplWithKeySuffix))
+            using (SessionFactory sessionFactory = GetSessionFactory(true, DefaultRegion))
+            {
+                using (Session<byte[], byte[]> sessionBytes = sessionFactory.GetSessionBytes("shopper123"))
+                {
+                    // Decrypt the payload
+                    decryptedBytes = sessionBytes.Decrypt(dataRowRecordBytes);
+                }
+            }
+
+            // Verify that we were able to decrypt with a suffixed builder
+            Assert.Equal(decryptedBytes, originalPayload);
+        }
+
+        [Fact]
+        private void TestCrossRegionDecryption()
+        {
+            byte[] originalPayload = PayloadGenerator.CreateDefaultRandomBytePayload();
+            byte[] decryptedBytes;
+            byte[] dataRowRecordBytes;
+
+            // Encrypt originalPayloadString with metastore without key suffix
+            using (SessionFactory sessionFactory = GetSessionFactory(true, DefaultRegion))
+            {
+                using (Session<byte[], byte[]> sessionBytes = sessionFactory.GetSessionBytes("shopper123"))
+                {
+                    dataRowRecordBytes = sessionBytes.Encrypt(originalPayload);
+                }
+            }
+
+            // Decrypt dataRowString with metastore with key suffix
+            using (SessionFactory sessionFactory = GetSessionFactory(true, "us-east-1"))
             {
                 using (Session<byte[], byte[]> sessionBytes = sessionFactory.GetSessionBytes("shopper123"))
                 {

--- a/csharp/AppEncryption/AppEncryption.IntegrationTests/Regression/DynamoDbGlobalTableTest.cs
+++ b/csharp/AppEncryption/AppEncryption.IntegrationTests/Regression/DynamoDbGlobalTableTest.cs
@@ -68,17 +68,17 @@ namespace GoDaddy.Asherah.AppEncryption.IntegrationTests.Regression
 
         private SessionFactory GetSessionFactory(bool withKeySuffix, string region)
         {
-        DynamoDbMetastoreImpl.IBuildStep builder = DynamoDbMetastoreImpl.NewBuilder(region)
-          .WithEndPointConfiguration("http://localhost:" + DynamoDbPort, "us-west-2");
+            DynamoDbMetastoreImpl.IBuildStep builder = DynamoDbMetastoreImpl.NewBuilder(region)
+                .WithEndPointConfiguration("http://localhost:" + DynamoDbPort, "us-west-2");
 
-        if (withKeySuffix)
-        {
-          builder = builder.WithKeySuffix();
+            if (withKeySuffix)
+            {
+                builder = builder.WithKeySuffix();
+            }
+
+            DynamoDbMetastoreImpl dynamoDbMetastore = builder.Build();
+            return SessionFactoryGenerator.CreateDefaultSessionFactory(configFixture.KeyManagementService, dynamoDbMetastore);
         }
-
-        DynamoDbMetastoreImpl dynamoDbMetastore = builder.Build();
-        return SessionFactoryGenerator.CreateDefaultSessionFactory(configFixture.KeyManagementService, dynamoDbMetastore);
-      }
 
         [Fact]
         private void TestRegionSuffix()

--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/DynamoDBContainerFixture.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/DynamoDBContainerFixture.cs
@@ -25,6 +25,7 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Persistence
                     .Begin()
                     .WithImage("amazon/dynamodb-local:latest")
                     .WithExposedPorts(8000)
+                    .WithPortBindings((8000, 8000))
                     .Build();
 
                 ServiceUrl = $"http://{DynamoDbContainer.GetDockerHostIpAddress()}:{DynamoDbContainer.ExposedPorts[0]}";

--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/SuffixedPartitionTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/SuffixedPartitionTest.cs
@@ -72,6 +72,9 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption
             const string intermediateKeyIdStringSuffixed = "_IK_" + TestPartitionId + "_" + TestServiceId + "_" + TestProductId + "_" + TestSuffixRegion;
             Assert.True(partition.IsValidIntermediateKeyId(intermediateKeyIdStringSuffixed));
 
+            const string intermediateKeyIdStringSuffixedOther = "_IK_" + TestPartitionId + "_" + TestServiceId + "_" + TestProductId + "_" + "other_suffix";
+            Assert.True(partition.IsValidIntermediateKeyId(intermediateKeyIdStringSuffixedOther));
+
             const string intermediateKeyIdString = "_IK_" + TestPartitionId + "_" + TestServiceId + "_" + TestProductId;
             Assert.True(partition.IsValidIntermediateKeyId(intermediateKeyIdString));
 

--- a/csharp/AppEncryption/AppEncryption/SuffixedPartition.cs
+++ b/csharp/AppEncryption/AppEncryption/SuffixedPartition.cs
@@ -37,7 +37,7 @@ namespace GoDaddy.Asherah.AppEncryption
 
         public override bool IsValidIntermediateKeyId(string keyId)
         {
-            return keyId.Equals(IntermediateKeyId) || keyId.Equals(base.IntermediateKeyId);
+            return keyId.Equals(IntermediateKeyId) || keyId.StartsWith(base.IntermediateKeyId);
         }
     }
 }

--- a/csharp/AppEncryption/Directory.Build.props
+++ b/csharp/AppEncryption/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.3</Version>
+    <Version>0.2.4</Version>
   </PropertyGroup>
 </Project>

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.godaddy.asherah</groupId>
   <artifactId>appencryption</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <name>Asherah</name>
   <description>
     An application-layer encryption SDK that provides advanced encryption features and in depth defense against

--- a/java/app-encryption/src/main/java/com/godaddy/asherah/appencryption/SuffixedPartition.java
+++ b/java/app-encryption/src/main/java/com/godaddy/asherah/appencryption/SuffixedPartition.java
@@ -37,6 +37,6 @@ public class SuffixedPartition extends Partition {
 
   @Override
   public boolean isValidIntermediateKeyId(final String id) {
-    return id.equals(getIntermediateKeyId()) || id.equals(super.getIntermediateKeyId());
+    return id.equals(getIntermediateKeyId()) || id.startsWith(super.getIntermediateKeyId());
   }
 }

--- a/java/app-encryption/src/test/java/com/godaddy/asherah/appencryption/SuffixedPartitionTest.java
+++ b/java/app-encryption/src/test/java/com/godaddy/asherah/appencryption/SuffixedPartitionTest.java
@@ -47,6 +47,10 @@ class SuffixedPartitionTest {
         "_IK_" + testPartitionId + "_" + testServiceId + "_" + testProductId + "_" + testRegionSuffix;
       assertTrue(partition.isValidIntermediateKeyId(intermediateKeyIdStringSuffixed));
 
+      String intermediateKeyIdStringSuffixedOther =
+        "_IK_" + testPartitionId + "_" + testServiceId + "_" + testProductId + "_" + "other_suffix";
+      assertTrue(partition.isValidIntermediateKeyId(intermediateKeyIdStringSuffixedOther));
+
       String intermediateKeyIdString =
         "_IK_" + testPartitionId + "_" + testServiceId + "_" + testProductId;
       assertTrue(partition.isValidIntermediateKeyId(intermediateKeyIdString));


### PR DESCRIPTION
- Update logic to check the start of keyId instead of the entire id for partitioned keys
- Add regression tests for cross-region encryption/decryption