### PR TITLE
Install openjdk-11 version 11.0.7+10-3ubuntu1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,7 @@ jobs:
           key: v5-clients-{{ .Branch }}-{{ .BuildNum }}
   tests-cross-language:
     docker:
-      - image: ubuntu:18.04
+      - image: ubuntu
         environment:
           GOROOT: /usr/local/go
           GOPATH: /go
@@ -646,7 +646,8 @@ jobs:
       - run:
           name: Setup java environment
           command: |
-            apt-get install -y openjdk-8-jdk openjdk-11-jdk
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+            apt-get install -y openjdk-8-jdk openjdk-11-jre-headless=11.0.7+10-3ubuntu1 openjdk-11-jdk-headless=11.0.7+10-3ubuntu1 openjdk-11-jre=11.0.7+10-3ubuntu1 openjdk-11-jdk=11.0.7+10-3ubuntu1
             apt-get install -y maven
             # Delete Java appencryption & gRPC server from local maven repo/cache and build from the current branch
             rm -rf ~/.m2/repository/com/godaddy/asherah/grpc-server ~/.m2/repository/com/godaddy/asherah/appencryption
@@ -674,9 +675,9 @@ jobs:
       - run:
           name: Setup python environment
           command: |
-            apt-get install -y python3.7 python3-distutils
+            apt-get install -y python3.8 python3-distutils
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-            python3.7 get-pip.py
+            python3.8 get-pip.py
       - run:
           name: Build
           command: |

--- a/tests/cross-language/scripts/decrypt_all.sh
+++ b/tests/cross-language/scripts/decrypt_all.sh
@@ -21,7 +21,7 @@ godog ../features/decrypt.feature
 cd ..
 
 cd sidecar
-pip3.7 install -r requirements.txt
+pip3.8 install -r requirements.txt
 echo "------------Decrypting data with Go sidecar and python client-----------"
 export ASHERAH_EXPIRE_AFTER=60m
 export ASHERAH_CHECK_INTERVAL=10m

--- a/tests/cross-language/scripts/encrypt_all.sh
+++ b/tests/cross-language/scripts/encrypt_all.sh
@@ -21,7 +21,7 @@ godog ../features/encrypt.feature
 cd ..
 
 cd sidecar
-pip3.7 install -r requirements.txt
+pip3.8 install -r requirements.txt
 echo "----------Encrypting payload with Go sidecar and python client----------"
 export ASHERAH_EXPIRE_AFTER=60m
 export ASHERAH_CHECK_INTERVAL=10m


### PR DESCRIPTION
This PR pins the JRE version installed in the cross-language-tests job to 11.0.7+10-3ubuntu1 since that allows database connections using TLSv1, which isn't allowed in newer versions - https://bugs.openjdk.java.net/browse/JDK-8254713 

Other updates include:
- Use ubuntu:latest image since the required JRE wasn't available in ubuntu:18.04
```
root@66ad93682d8e:/# apt-cache madison openjdk-11-jre
openjdk-11-jre | 11.0.11+9-0ubuntu2~18.04 | http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages
openjdk-11-jre | 11.0.11+9-0ubuntu2~18.04 | http://security.ubuntu.com/ubuntu bionic-security/main amd64 Packages
openjdk-11-jre | 10.0.1+10-3ubuntu1 | http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages
```
- Update CLTF to use python3.8