### PR TITLE
Use custom PAT in sync-release

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -20,4 +20,4 @@ jobs:
           type: now
           head_to_merge: master
           target_branch: ${{ github.event.inputs.target }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.MERGE_TOKEN }}


### PR DESCRIPTION
Push action doesn't trigger subsequent workflow ire we're using the default token provided by GitHub Actions. https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854
Use a custom token in the sync-release workflow to trigger subsequent actions.