### PR TITLE
Updates for C# and Java release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,7 @@ jobs:
           path: ${{ github.workspace }}/csharp/Logging/Logging
       - name: Publish C# Logging
         run: |
+          sudo apt-get install -y libxml2-utils
           cd csharp/Logging
           BASE_VERSION=$(xmllint --xpath "//Project/PropertyGroup/Version/text()" Directory.Build.props)
           VERSION_SUFFIX=`echo ${BASE_VERSION} | cut -f2 -d'-'`
@@ -318,6 +319,7 @@ jobs:
             ${{ github.workspace }}/csharp/SecureMemory/PlatformNative
       - name: Publish C# Secure Memory
         run: |
+          sudo apt-get install -y libxml2-utils
           cd csharp/SecureMemory
           BASE_VERSION=$(xmllint --xpath "//Project/PropertyGroup/Version/text()" Directory.Build.props)
           VERSION_SUFFIX=`echo ${BASE_VERSION} | cut -f2 -d'-'`
@@ -394,6 +396,7 @@ jobs:
           path: ${{ github.workspace }}/csharp/AppEncryption/AppEncryption
       - name: Publish App Encryption
         run: |
+          sudo apt-get install -y libxml2-utils
           cd csharp/AppEncryption
           BASE_VERSION=$(xmllint --xpath "//Project/PropertyGroup/Version/text()" Directory.Build.props)
           VERSION_SUFFIX=`echo ${BASE_VERSION} | cut -f2 -d'-'`

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -413,6 +413,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/java/secure-memory/pom.xml
+++ b/java/secure-memory/pom.xml
@@ -231,6 +231,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.6</version>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
- C# jobs need xmllint to extract version from the `Directory.Build.props` file
- Maven GPG plugin coffin must be updated as per https://github.com/actions/setup-java/issues/83 in order for successful maven setup