### PR TITLE
Temporarily build and pack C# artifacts

### DIFF
--- a/build/csharp/release_prod.sh
+++ b/build/csharp/release_prod.sh
@@ -8,7 +8,7 @@ TAG=`echo csharp/${ARTIFACT_NAME}/v${BASE_VERSION}`
 
 RESULT=$(git tag -l ${TAG})
 if [[ "$RESULT" != ${TAG} ]]; then
-    dotnet pack -c Release --no-build
+    dotnet pack -c Release
     echo "Releasing ${ARTIFACT_NAME} artifact"
     find . -name *${BASE_VERSION}.nupkg  | xargs -L1 -I '{}' dotnet nuget push {} -k ${NUGET_KEY} -s ${NUGET_SOURCE}
 


### PR DESCRIPTION
C# releases currently fail because it is unable to find the required dependencies to build the projects. This is likely caused by an issue with caching. There are quite a few issues (open and closed) in the actions/cache repo. Until a more robust solution is implemented for C# release, build and pack artifacts on the release branches.
https://github.com/godaddy/asherah/issues/380 filed to keep this on our radar.