### PR TITLE
Update C# AE csproj file

### DIFF
--- a/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
+++ b/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
@@ -6,6 +6,8 @@
     <Company>GoDaddy</Company>
     <Description>Application level envelope encryption SDK for C#</Description>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!-- NOTE: Version controlled via Directory.Build.props  -->
     <!--<Version></Version>-->
     <RootNamespace>GoDaddy.Asherah.AppEncryption</RootNamespace>

--- a/csharp/AppEncryption/Crypto/Crypto.csproj
+++ b/csharp/AppEncryption/Crypto/Crypto.csproj
@@ -4,6 +4,8 @@
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!-- NOTE: Version controlled via Directory.Build.props  -->
     <!--<Version></Version>-->
     <RootNamespace>GoDaddy.Asherah.Crypto</RootNamespace>


### PR DESCRIPTION
Currently, the CI for C# AppEncryption fails with the following error.
```
/home/runner/work/asherah/asherah/csharp/AppEncryption/AppEncryption/AppEncryption/obj/Release/netstandard2.1/.NETStandard,Version=v2.1.AssemblyAttributes.cs(4,12): error CS0579: Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attribute
```
The proposed solution is derived from this SO article - https://stackoverflow.com/questions/61997928/errorcs0579duplicate-globalsystem-runtime-versioning-targetframeworkattribu

Verified that the solution works here - https://github.com/sushantmimani/asherah/runs/3000940891?check_suite_focus=true
The failure is due to missing secrets in the fork.