### PR TITLE
Option to set Aurora replica read consistency

### DIFF
--- a/server/go/README.md
+++ b/server/go/README.md
@@ -45,33 +45,35 @@ Usage:
   server [OPTIONS]
 
 Application Options:
-  -s, --socket-file=                      The unix domain socket the server will listen on (default:
-                                          /tmp/appencryption.sock)
+  -s, --socket-file=                                       The unix domain socket the server will listen on (default:
+                                                           /tmp/appencryption.sock)
 
 Asherah Options:
-      --service=                          The name of this service [$ASHERAH_SERVICE_NAME]
-      --product=                          The name of the product that owns this service [$ASHERAH_PRODUCT_NAME]
-      --expire-after=                     The amount of time a key is considered valid [$ASHERAH_EXPIRE_AFTER]
-      --check-interval=                   The amount of time before cached keys are considered stale
-                                          [$ASHERAH_CHECK_INTERVAL]
-      --metastore=[rdbms|dynamodb|memory] Determines the type of metastore to use for persisting keys
-                                          [$ASHERAH_METASTORE_MODE]
-      --conn=                             The database connection string (required if --metastore=rdbms)
-                                          [$ASHERAH_CONNECTION_STRING]
-      --enable-region-suffix              Configure the metastore to use regional suffixes (only supported by
-                                          --metastore=dynamodb) [$ASHERAH_ENABLE_REGION_SUFFIX]
-      --dynamodb-endpoint=                An optional endpoint URL (hostname only or fully qualified URI) (only
-                                          supported by --metastore=dynamodb) [$ASHERAH_DYNAMODB_ENDPOINT]
-      --dynamodb-region=                  The AWS region for DynamoDB requests (defaults to globally configured region)
-                                          (only supported by --metastore=dynamodb) [$ASHERAH_DYNAMODB_REGION]
-      --dynamodb-table-name=              The table name for DynamoDB (only supported by --metastore=dynamodb)
-                                          [$ASHERAH_DYNAMODB_TABLE_NAME]
-      --kms=[aws|static]                  Configures the master key management service (default: aws)
-                                          [$ASHERAH_KMS_MODE]
-      --region-map=                       A comma separated list of key-value pairs in the form of
-                                          REGION1=ARN1[,REGION2=ARN2] (required if --kms=aws) [$ASHERAH_REGION_MAP]
-      --preferred-region=                 The preferred AWS region (required if --kms=aws) [$ASHERAH_PREFERRED_REGION]
+      --service=                                           The name of this service [$ASHERAH_SERVICE_NAME]
+      --product=                                           The name of the product that owns this service [$ASHERAH_PRODUCT_NAME]
+      --expire-after=                                      The amount of time a key is considered valid [$ASHERAH_EXPIRE_AFTER]
+      --check-interval=                                    The amount of time before cached keys are considered stale
+                                                           [$ASHERAH_CHECK_INTERVAL]
+      --metastore=[rdbms|dynamodb|memory]                  Determines the type of metastore to use for persisting keys
+                                                           [$ASHERAH_METASTORE_MODE]
+      --conn=                                              The database connection string (required if --metastore=rdbms)
+                                                           [$ASHERAH_CONNECTION_STRING]
+      --replica-read-consistency=[eventual|global|session] Required for Aurora sessions using write forwarding (if --metastore=rdbms)
+                                                           [$ASHERAH_REPLICA_READ_CONSISTENCY]
+      --enable-region-suffix                               Configure the metastore to use regional suffixes (only supported by
+                                                           --metastore=dynamodb) [$ASHERAH_ENABLE_REGION_SUFFIX]
+      --dynamodb-endpoint=                                 An optional endpoint URL (hostname only or fully qualified URI) (only
+                                                           supported by --metastore=dynamodb) [$ASHERAH_DYNAMODB_ENDPOINT]
+      --dynamodb-region=                                   The AWS region for DynamoDB requests (defaults to globally configured region)
+                                                           (only supported by --metastore=dynamodb) [$ASHERAH_DYNAMODB_REGION]
+      --dynamodb-table-name=                               The table name for DynamoDB (only supported by --metastore=dynamodb)
+                                                           [$ASHERAH_DYNAMODB_TABLE_NAME]
+      --kms=[aws|static]                                   Configures the master key management service (default: aws)
+                                                           [$ASHERAH_KMS_MODE]
+      --region-map=                                        A comma separated list of key-value pairs in the form of
+                                                           REGION1=ARN1[,REGION2=ARN2] (required if --kms=aws) [$ASHERAH_REGION_MAP]
+      --preferred-region=                                  The preferred AWS region (required if --kms=aws) [$ASHERAH_PREFERRED_REGION]
 
 Help Options:
-  -h, --help                              Show this help message
+  -h, --help                                               Show this help message
 ```

--- a/server/go/pkg/server/database.go
+++ b/server/go/pkg/server/database.go
@@ -6,6 +6,13 @@ import (
 	"github.com/go-sql-driver/mysql"
 )
 
+const (
+	ReplicaReadConsistencyQuery         = "SET aurora_replica_read_consistency = ?"
+	ReplicaReadConsistencyValueEventual = "eventual"
+	ReplicaReadConsistencyValueGlobal   = "global"
+	ReplicaReadConsistencyValueSession  = "session"
+)
+
 var (
 	dbconnection *sql.DB
 	dbdriver     = "mysql"
@@ -27,4 +34,17 @@ func newMysql(connStr string) (*sql.DB, error) {
 	}
 
 	return dbconnection, nil
+}
+
+func setRdbmsReplicaReadConsistencyValue(value string) (err error) {
+	if dbconnection != nil {
+		switch value {
+		case
+			ReplicaReadConsistencyValueEventual,
+			ReplicaReadConsistencyValueGlobal,
+			ReplicaReadConsistencyValueSession:
+			_, err = dbconnection.Exec(ReplicaReadConsistencyQuery, value)
+		}
+	}
+	return
 }

--- a/server/go/pkg/server/database.go
+++ b/server/go/pkg/server/database.go
@@ -46,5 +46,6 @@ func setRdbmsReplicaReadConsistencyValue(value string) (err error) {
 			_, err = dbconnection.Exec(ReplicaReadConsistencyQuery, value)
 		}
 	}
+
 	return
 }

--- a/server/go/pkg/server/database_test.go
+++ b/server/go/pkg/server/database_test.go
@@ -1,19 +1,60 @@
 package server
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	readConsistencyValue string
+)
+
+type FakeResult struct {}
+
+func (r *FakeResult) LastInsertId() (int64, error) {
+	return 0, nil
+}
+
+func (r *FakeResult) RowsAffected() (int64, error) {
+	return 0, nil
+}
+
+type FakeConn struct {
+}
+
+func (c *FakeConn) Begin() (driver.Tx, error) {
+	return nil, nil
+}
+
+func (c *FakeConn) Close() error {
+	return nil
+}
+
+func (c *FakeConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	result := &FakeResult{}
+	switch query {
+	case ReplicaReadConsistencyQuery:
+		readConsistencyValue = fmt.Sprintf("%v", args[0].Value)
+	}
+	return result, nil
+}
+
+func (c *FakeConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, nil
+}
+
 type FakeDriver struct {
 }
 
 func (f *FakeDriver) Open(name string) (driver.Conn, error) {
-	return nil, nil
+	conn := &FakeConn{}
+	return conn, nil
 }
 
 func TestMain(m *testing.M) {
@@ -31,4 +72,30 @@ func TestNewMysql(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, dbconnection)
+}
+
+func TestSetRdbmsReplicaReadConsistencyValue(t *testing.T) {
+	dbconnection = nil
+
+	var err error
+	db, err := newMysql("root:secret@(localhost:%s)/mysql")
+	assert.Nil(t, err)
+	assert.NotNil(t, db)
+
+	// empty
+	err = setRdbmsReplicaReadConsistencyValue("")
+	assert.Nil(t, err)
+	assert.Equal(t, "", readConsistencyValue)
+	// eventual
+	err = setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueEventual)
+	assert.Nil(t, err)
+	assert.Equal(t, ReplicaReadConsistencyValueEventual, readConsistencyValue)
+	// global
+	err = setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueGlobal)
+	assert.Nil(t, err)
+	assert.Equal(t, ReplicaReadConsistencyValueGlobal, readConsistencyValue)
+	// session
+	err = setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueSession)
+	assert.Nil(t, err)
+	assert.Equal(t, ReplicaReadConsistencyValueSession, readConsistencyValue)
 }

--- a/server/go/pkg/server/database_test.go
+++ b/server/go/pkg/server/database_test.go
@@ -39,6 +39,7 @@ func (c *FakeConn) Close() error {
 
 func (c *FakeConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	result := &FakeResult{}
+
 	if query == ReplicaReadConsistencyQuery {
 		readConsistencyValue = fmt.Sprintf("%v", args[0].Value)
 	}

--- a/server/go/pkg/server/database_test.go
+++ b/server/go/pkg/server/database_test.go
@@ -76,13 +76,13 @@ func TestNewMysql(t *testing.T) {
 	assert.NotNil(t, dbconnection)
 }
 
-func resetTestDb() {
+func resetTestDB() {
 	dbconnection = nil
 	_, _ = newMysql("root:secret@(localhost:%s)/mysql")
 }
 
 func TestSetRdbmsReplicaReadConsistencyValueEmpty(t *testing.T) {
-	resetTestDb()
+	resetTestDB()
 
 	err := setRdbmsReplicaReadConsistencyValue("")
 	assert.Nil(t, err)
@@ -90,7 +90,7 @@ func TestSetRdbmsReplicaReadConsistencyValueEmpty(t *testing.T) {
 }
 
 func TestSetRdbmsReplicaReadConsistencyValueEventual(t *testing.T) {
-	resetTestDb()
+	resetTestDB()
 
 	err := setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueEventual)
 	assert.Nil(t, err)
@@ -98,7 +98,7 @@ func TestSetRdbmsReplicaReadConsistencyValueEventual(t *testing.T) {
 }
 
 func TestSetRdbmsReplicaReadConsistencyValueGlobal(t *testing.T) {
-	resetTestDb()
+	resetTestDB()
 
 	err := setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueGlobal)
 	assert.Nil(t, err)
@@ -106,7 +106,7 @@ func TestSetRdbmsReplicaReadConsistencyValueGlobal(t *testing.T) {
 }
 
 func TestSetRdbmsReplicaReadConsistencyValueSession(t *testing.T) {
-	resetTestDb()
+	resetTestDB()
 
 	err := setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueSession)
 	assert.Nil(t, err)

--- a/server/go/pkg/server/database_test.go
+++ b/server/go/pkg/server/database_test.go
@@ -76,28 +76,39 @@ func TestNewMysql(t *testing.T) {
 	assert.NotNil(t, dbconnection)
 }
 
-func TestSetRdbmsReplicaReadConsistencyValue(t *testing.T) {
+func resetTestDb() {
 	dbconnection = nil
+	_, _ = newMysql("root:secret@(localhost:%s)/mysql")
+}
 
-	var err error
-	db, err := newMysql("root:secret@(localhost:%s)/mysql")
-	assert.Nil(t, err)
-	assert.NotNil(t, db)
+func TestSetRdbmsReplicaReadConsistencyValueEmpty(t *testing.T) {
+	resetTestDb()
 
-	// empty
-	err = setRdbmsReplicaReadConsistencyValue("")
+	err := setRdbmsReplicaReadConsistencyValue("")
 	assert.Nil(t, err)
 	assert.Equal(t, "", readConsistencyValue)
-	// eventual
-	err = setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueEventual)
+}
+
+func TestSetRdbmsReplicaReadConsistencyValueEventual(t *testing.T) {
+	resetTestDb()
+
+	err := setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueEventual)
 	assert.Nil(t, err)
 	assert.Equal(t, ReplicaReadConsistencyValueEventual, readConsistencyValue)
-	// global
-	err = setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueGlobal)
+}
+
+func TestSetRdbmsReplicaReadConsistencyValueGlobal(t *testing.T) {
+	resetTestDb()
+
+	err := setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueGlobal)
 	assert.Nil(t, err)
 	assert.Equal(t, ReplicaReadConsistencyValueGlobal, readConsistencyValue)
-	// session
-	err = setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueSession)
+}
+
+func TestSetRdbmsReplicaReadConsistencyValueSession(t *testing.T) {
+	resetTestDb()
+
+	err := setRdbmsReplicaReadConsistencyValue(ReplicaReadConsistencyValueSession)
 	assert.Nil(t, err)
 	assert.Equal(t, ReplicaReadConsistencyValueSession, readConsistencyValue)
 }

--- a/server/go/pkg/server/database_test.go
+++ b/server/go/pkg/server/database_test.go
@@ -15,7 +15,8 @@ var (
 	readConsistencyValue string
 )
 
-type FakeResult struct {}
+type FakeResult struct {
+}
 
 func (r *FakeResult) LastInsertId() (int64, error) {
 	return 0, nil
@@ -38,10 +39,10 @@ func (c *FakeConn) Close() error {
 
 func (c *FakeConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
 	result := &FakeResult{}
-	switch query {
-	case ReplicaReadConsistencyQuery:
+	if query == ReplicaReadConsistencyQuery {
 		readConsistencyValue = fmt.Sprintf("%v", args[0].Value)
 	}
+
 	return result, nil
 }
 

--- a/server/go/pkg/server/options.go
+++ b/server/go/pkg/server/options.go
@@ -8,23 +8,24 @@ import (
 
 //nolint:lll,staticcheck
 type Options struct {
-	ServiceName          string        `long:"service" required:"yes" description:"The name of this service" env:"ASHERAH_SERVICE_NAME"`
-	ProductID            string        `long:"product" required:"yes" description:"The name of the product that owns this service" env:"ASHERAH_PRODUCT_NAME"`
-	ExpireAfter          time.Duration `long:"expire-after" description:"The amount of time a key is considered valid" env:"ASHERAH_EXPIRE_AFTER"`
-	CheckInterval        time.Duration `long:"check-interval" description:"The amount of time before cached keys are considered stale" env:"ASHERAH_CHECK_INTERVAL"`
-	Metastore            string        `long:"metastore" choice:"rdbms" choice:"dynamodb" choice:"memory" required:"yes" description:"Determines the type of metastore to use for persisting keys" env:"ASHERAH_METASTORE_MODE"`
-	ConnectionString     string        `long:"conn" default-mask:"-" description:"The database connection string (required if --metastore=rdbms)" env:"ASHERAH_CONNECTION_STRING"`
-	DynamoDBEndpoint     string        `long:"dynamodb-endpoint" description:"An optional endpoint URL (hostname only or fully qualified URI) (only supported by --metastore=dynamodb)" env:"ASHERAH_DYNAMODB_ENDPOINT"`
-	DynamoDBRegion       string        `long:"dynamodb-region" description:"The AWS region for DynamoDB requests (defaults to globally configured region) (only supported by --metastore=dynamodb)" env:"ASHERAH_DYNAMODB_REGION"`
-	DynamoDBTableName    string        `long:"dynamodb-table-name" description:"The table name for DynamoDB (only supported by --metastore=dynamodb)" env:"ASHERAH_DYNAMODB_TABLE_NAME"`
-	SessionCacheMaxSize  int           `long:"session-cache-max-size" default:"1000" description:"Define the maximum number of sessions to cache" env:"ASHERAH_SESSION_CACHE_MAX_SIZE"`
-	SessionCacheDuration time.Duration `long:"session-cache-duration" default:"2h" description:"The amount of time a session will remain cached" env:"ASHERAH_SESSION_CACHE_DURATION"`
-	KMS                  string        `long:"kms" choice:"aws" choice:"static" default:"aws" description:"Configures the master key management service" env:"ASHERAH_KMS_MODE"`
-	RegionMap            RegionMap     `long:"region-map" description:"A comma separated list of key-value pairs in the form of REGION1=ARN1[,REGION2=ARN2] (required if --kms=aws)" env:"ASHERAH_REGION_MAP"`
-	PreferredRegion      string        `long:"preferred-region" description:"The preferred AWS region (required if --kms=aws)" env:"ASHERAH_PREFERRED_REGION"`
-	EnableRegionSuffix   bool          `long:"enable-region-suffix" description:"Configure the metastore to use regional suffixes (only supported by --metastore=dynamodb)" env:"ASHERAH_ENABLE_REGION_SUFFIX"`
-	EnableSessionCaching bool          `long:"enable-session-caching" description:"Enable shared session caching" env:"ASHERAH_ENABLE_SESSION_CACHING"`
-	Verbose              bool          `short:"v" long:"verbose" description:"Enable verbose logging output" env:"ASHERAH_VERBOSE"`
+	ServiceName            string        `long:"service" required:"yes" description:"The name of this service" env:"ASHERAH_SERVICE_NAME"`
+	ProductID              string        `long:"product" required:"yes" description:"The name of the product that owns this service" env:"ASHERAH_PRODUCT_NAME"`
+	ExpireAfter            time.Duration `long:"expire-after" description:"The amount of time a key is considered valid" env:"ASHERAH_EXPIRE_AFTER"`
+	CheckInterval          time.Duration `long:"check-interval" description:"The amount of time before cached keys are considered stale" env:"ASHERAH_CHECK_INTERVAL"`
+	Metastore              string        `long:"metastore" choice:"rdbms" choice:"dynamodb" choice:"memory" required:"yes" description:"Determines the type of metastore to use for persisting keys" env:"ASHERAH_METASTORE_MODE"`
+	ConnectionString       string        `long:"conn" default-mask:"-" description:"The database connection string (required if --metastore=rdbms)" env:"ASHERAH_CONNECTION_STRING"`
+	ReplicaReadConsistency string        `long:"replica-read-consistency" choice:"eventual" choice:"global" choice:"session" description:"Required for Aurora sessions using write forwarding" env:"ASHERAH_REPLICA_READ_CONSISTENCY"`
+	DynamoDBEndpoint       string        `long:"dynamodb-endpoint" description:"An optional endpoint URL (hostname only or fully qualified URI) (only supported by --metastore=dynamodb)" env:"ASHERAH_DYNAMODB_ENDPOINT"`
+	DynamoDBRegion         string        `long:"dynamodb-region" description:"The AWS region for DynamoDB requests (defaults to globally configured region) (only supported by --metastore=dynamodb)" env:"ASHERAH_DYNAMODB_REGION"`
+	DynamoDBTableName      string        `long:"dynamodb-table-name" description:"The table name for DynamoDB (only supported by --metastore=dynamodb)" env:"ASHERAH_DYNAMODB_TABLE_NAME"`
+	SessionCacheMaxSize    int           `long:"session-cache-max-size" default:"1000" description:"Define the maximum number of sessions to cache" env:"ASHERAH_SESSION_CACHE_MAX_SIZE"`
+	SessionCacheDuration   time.Duration `long:"session-cache-duration" default:"2h" description:"The amount of time a session will remain cached" env:"ASHERAH_SESSION_CACHE_DURATION"`
+	KMS                    string        `long:"kms" choice:"aws" choice:"static" default:"aws" description:"Configures the master key management service" env:"ASHERAH_KMS_MODE"`
+	RegionMap              RegionMap     `long:"region-map" description:"A comma separated list of key-value pairs in the form of REGION1=ARN1[,REGION2=ARN2] (required if --kms=aws)" env:"ASHERAH_REGION_MAP"`
+	PreferredRegion        string        `long:"preferred-region" description:"The preferred AWS region (required if --kms=aws)" env:"ASHERAH_PREFERRED_REGION"`
+	EnableRegionSuffix     bool          `long:"enable-region-suffix" description:"Configure the metastore to use regional suffixes (only supported by --metastore=dynamodb)" env:"ASHERAH_ENABLE_REGION_SUFFIX"`
+	EnableSessionCaching   bool          `long:"enable-session-caching" description:"Enable shared session caching" env:"ASHERAH_ENABLE_SESSION_CACHING"`
+	Verbose                bool          `short:"v" long:"verbose" description:"Enable verbose logging output" env:"ASHERAH_VERBOSE"`
 }
 
 type RegionMap map[string]string

--- a/server/go/pkg/server/server.go
+++ b/server/go/pkg/server/server.go
@@ -86,6 +86,14 @@ func NewMetastore(opts *Options) appencryption.Metastore {
 			panic(err)
 		}
 
+		// set optional replica read consistency
+		if len(opts.ReplicaReadConsistency) > 0 {
+			err := setRdbmsReplicaReadConsistencyValue(opts.ReplicaReadConsistency)
+			if err != nil {
+				panic(err)
+			}
+		}
+
 		return persistence.NewSQLMetastore(db)
 	case "dynamodb":
 		awsOpts := awssession.Options{

--- a/server/go/pkg/server/server_test.go
+++ b/server/go/pkg/server/server_test.go
@@ -345,6 +345,7 @@ func Test_NewAppEncryption(t *testing.T) {
 	// using a variety of configuration options.
 	optCombos := []*Options{
 		{KMS: "aws", Metastore: "rdbms"},
+		{KMS: "aws", Metastore: "rdbms", ReplicaReadConsistency: "session"},
 		{KMS: "aws", Metastore: "dynamodb"},
 		{KMS: "aws", Metastore: "dynamodb", DynamoDBRegion: "us-east-1"},
 		{KMS: "aws", Metastore: "dynamodb", DynamoDBEndpoint: "http://localhost:8000"},


### PR DESCRIPTION
This PR adds an option to the Golang sidecar server to optionally set the `aurora_replica_read_consistency` parameter to allow global write forwarding to function correctly:

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database-write-forwarding.html

Without this patch, a sidecar connected to a secondary cluster with write forwarding enabled will fail because it cannot write to the database. With this patch, the database session is primed with the value given in the new option and writes function correctly.