### PR TITLE
Test fixes for multiple platforms

### DIFF
--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -85,42 +85,66 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
         }
 
         [SkippableFact]
-        private void TestAlocWithResourceLimitZero()
+        private void TestAllocWithResourceLimitZeroShouldFail()
         {
             Skip.If(libc == null);
 
-            var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
-            allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(0);
-
-            var allocator = allocatorMock.Object;
-            Assert.Throws<MemoryLimitException>(() =>
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                allocator.Alloc(1);
-            });
+                var allocatorMock = new Mock<MacOSProtectedMemoryAllocatorLP64>() { CallBase = true };
+                allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(0);
+                Assert.Throws<MemoryLimitException>(() =>
+                {
+                    allocatorMock.Object.Alloc(1);
+                });
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
+                allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(0);
+                Assert.Throws<MemoryLimitException>(() =>
+                {
+                    allocatorMock.Object.Alloc(1);
+                });
+            }
         }
 
         [SkippableFact]
-        private void TestAlocWithResourceLimitMaxValue()
+        private void TestAllocWithResourceLimitMaxValueShouldSucceed()
         {
             Skip.If(libc == null);
 
-            var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
-            allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(ulong.MaxValue);
-
-            var allocator = allocatorMock.Object;
-            allocator.Alloc(1);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                var allocatorMock = new Mock<MacOSProtectedMemoryAllocatorLP64>() { CallBase = true };
+                allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(ulong.MaxValue);
+                allocatorMock.Object.Alloc(1);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
+                allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(ulong.MaxValue);
+                allocatorMock.Object.Alloc(1);
+            }
         }
 
         [SkippableFact]
-        private void TestAlocWithResourceLimitLargeValue()
+        private void TestAllocWithResourceLimitLargeValueShouldSucceed()
         {
             Skip.If(libc == null);
 
-            var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
-            allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(ulong.MaxValue-1);
-
-            var allocator = allocatorMock.Object;
-            allocator.Alloc(1);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                var allocatorMock = new Mock<MacOSProtectedMemoryAllocatorLP64>() { CallBase = true };
+                allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(ulong.MaxValue-1);
+                allocatorMock.Object.Alloc(1);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                var allocatorMock = new Mock<LinuxProtectedMemoryAllocatorLP64>() { CallBase = true };
+                allocatorMock.Setup(x => x.GetMemlockResourceLimit()).Returns(ulong.MaxValue-1);
+                allocatorMock.Object.Alloc(1);
+            }
         }
 
         [SkippableFact]

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/ProtectedMemorySecretFactoryTest.cs
@@ -45,18 +45,38 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl
         }
 
         [SkippableFact]
-        private void TestOpenSSLConfiguration()
+        private void TestOpenSSLConfigurationLinux()
         {
-            Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
+            {
+                {"secureHeapEngine", "openssl11"}
+            }).Build();
+
+            Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestOpenSSLConfigurationLinux");
+            using (var factory = new ProtectedMemorySecretFactory(configuration))
+            {
+            }
+        }
+
+        [SkippableFact]
+        private void TestOpenSSLConfigurationMacOS()
+        {
+            Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+
             var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()
             {
                 {"secureHeapEngine", "openssl11"}
             }).Build();
 
             Debug.WriteLine("ProtectedMemorySecretFactoryTest.TestOpenSSLConfiguration");
-            using (var factory = new ProtectedMemorySecretFactory(configuration))
+            Assert.Throws<PlatformNotSupportedException>(() =>
             {
-            }
+                using (var factory = new ProtectedMemorySecretFactory(configuration))
+                {
+                }
+            });
         }
 
         [Fact]

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/ProtectedMemorySecretFactory.cs
@@ -141,7 +141,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
                             throw new PlatformNotSupportedException("Non-64bit process not supported on macOS X64 or Arm64");
                         }
 
-                        return new MacOSProtectedMemoryAllocatorLP64();
+                        return ConfigureForMacOS64(configuration);
                     case Architecture.X86:
                         throw new PlatformNotSupportedException("Unsupported architecture macOS X86");
                     case Architecture.Arm:
@@ -208,6 +208,31 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl
             }
 
             return new LinuxProtectedMemoryAllocatorLP64();
+        }
+
+        private static IProtectedMemoryAllocator ConfigureForMacOS64(IConfiguration configuration)
+        {
+            if (configuration != null)
+            {
+                var secureHeapEngine = configuration["secureHeapEngine"];
+                if (!string.IsNullOrWhiteSpace(secureHeapEngine))
+                {
+                    if (string.Compare(secureHeapEngine, "openssl11", StringComparison.InvariantCultureIgnoreCase) == 0)
+                    {
+                        throw new PlatformNotSupportedException(
+                            "OpenSSL 1.1 selected for secureHeapEngine but is not yet supported for MacOS");
+                    }
+
+                    if (string.Compare(secureHeapEngine, "mmap", StringComparison.InvariantCultureIgnoreCase) == 0)
+                    {
+                        return new MacOSProtectedMemoryAllocatorLP64();
+                    }
+
+                    throw new PlatformNotSupportedException("Unknown secureHeapEngine: " + secureHeapEngine);
+                }
+            }
+
+            return new MacOSProtectedMemoryAllocatorLP64();
         }
 
         [ExcludeFromCodeCoverage]


### PR DESCRIPTION
In addition to the test fixes for multiple platforms (mainly macOS), `ProtectedMemorySecretFactory` will now throw a `PlatformNotSupportedException` when configured with `secureHeapEngine=openssl11` on macOS, instead of silently falling back to `mmap`.