### PR TITLE
[cicd] fix go paths

### DIFF
--- a/server/samples/clients/test_clients.sh
+++ b/server/samples/clients/test_clients.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export PATH=${GOROOT}/bin:${PATH}
+go version
 
 export ASHERAH_SERVICE_NAME=service
 export ASHERAH_PRODUCT_NAME=product

--- a/tests/cross-language/scripts/decrypt_all.sh
+++ b/tests/cross-language/scripts/decrypt_all.sh
@@ -2,7 +2,8 @@
 
 set -ex
 
-export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export PATH=${GOROOT}/bin:${PATH}
+go version
 
 TEST_DB_PORT="${TEST_DB_PORT:-3306}"
 TEST_DB_NAME="${TEST_DB_NAME:-testdb}"

--- a/tests/cross-language/scripts/encrypt_all.sh
+++ b/tests/cross-language/scripts/encrypt_all.sh
@@ -2,7 +2,8 @@
 
 set -ex
 
-export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+export PATH=${GOROOT}/bin:${PATH}
+go version
 
 TEST_DB_PORT="${TEST_DB_PORT:-3306}"
 TEST_DB_NAME="${TEST_DB_NAME:-testdb}"


### PR DESCRIPTION
Removed $GOPATH/bin from path as it resolves to /bin which is
not what we want, especially when preceding $GOROOT/bin as it
was