### PR TITLE
Bump C# SecureMemory version

### DIFF
--- a/csharp/SecureMemory/Directory.Build.props
+++ b/csharp/SecureMemory/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Update C# SecureMemory to 0.2.1 for release.