### PR TITLE
Fix snyk issues by updating packages and build sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
     needs: csharp-logging
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/dotnet/sdk:3.1
+      image: mcr.microsoft.com/dotnet/sdk:6.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - name: Checkout the repository
@@ -306,6 +306,7 @@ jobs:
     - name: Build
       run: |
         cd csharp/SecureMemory
+        ./scripts/install-dotnet-3.1.sh
         ./scripts/clean.sh
         ./scripts/build.sh
     - name: Test

--- a/build/csharp/install-dotnet-3.1.sh
+++ b/build/csharp/install-dotnet-3.1.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+dpkg -i packages-microsoft-prod.deb
+rm packages-microsoft-prod.deb
+
+apt-get update
+apt-get install -y dotnet-sdk-3.1

--- a/csharp/SecureMemory/SecureMemory/SecureMemory.csproj
+++ b/csharp/SecureMemory/SecureMemory/SecureMemory.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>GoDaddy.Asherah.SecureMemory</PackageId>
@@ -26,8 +26,8 @@
     </PackageReference>
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 

--- a/csharp/SecureMemory/scripts/install-dotnet-3.1.sh
+++ b/csharp/SecureMemory/scripts/install-dotnet-3.1.sh
@@ -1,0 +1,1 @@
+../../../build/csharp/install-dotnet-3.1.sh


### PR DESCRIPTION
This PR provides the minimal changes to fix the security issues Snyk has identified.  It upgrades the relevant packages, and then switches the build of SecureMemory to use sdk 6.0 with 3.1 targeting installed which is required to build the newer packages.  See issue: https://github.com/dotnet/runtime/issues/61602

