### PR TITLE
Add GPG plugin config

### DIFF
--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -455,6 +455,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>${maven.gpg.version}</version>
+              <configuration>
+                  <!-- Prevent gpg from using pinentry programs -->
+                  <gpgArguments>
+                      <arg>--pinentry-mode</arg>
+                      <arg>loopback</arg>
+                  </gpgArguments>
+              </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/java/app-encryption/pom.xml
+++ b/java/app-encryption/pom.xml
@@ -455,13 +455,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>${maven.gpg.version}</version>
-              <configuration>
-                  <!-- Prevent gpg from using pinentry programs -->
-                  <gpgArguments>
-                      <arg>--pinentry-mode</arg>
-                      <arg>loopback</arg>
-                  </gpgArguments>
-              </configuration>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/java/secure-memory/pom.xml
+++ b/java/secure-memory/pom.xml
@@ -234,13 +234,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>${maven.gpg.version}</version>
-              <configuration>
-                  <!-- Prevent gpg from using pinentry programs -->
-                  <gpgArguments>
-                      <arg>--pinentry-mode</arg>
-                      <arg>loopback</arg>
-                  </gpgArguments>
-              </configuration>
+            <configuration>
+              <!-- Prevent gpg from using pinentry programs -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/java/secure-memory/pom.xml
+++ b/java/secure-memory/pom.xml
@@ -234,6 +234,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>${maven.gpg.version}</version>
+              <configuration>
+                  <!-- Prevent gpg from using pinentry programs -->
+                  <gpgArguments>
+                      <arg>--pinentry-mode</arg>
+                      <arg>loopback</arg>
+                  </gpgArguments>
+              </configuration>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
The setup-java [docs](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#extra-setup-for-pomxml) state the this additional config is still required for the maven GPG plugin to avoid errors like `Inappropriate ioctl for device or gpg: signing failed: No such file or directory`