### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+To help us get this pull request reviewed and merged quickly, please be sure to include the following items:
+
+* [ ] Tests (if applicable)
+* [ ] Documentation (if applicable)
+* [ ] Changelog entry
+* [ ] A full explanation here in the PR description of the work done
+
+## PR Type
+What kind of change does this PR introduce?
+
+* [ ] Bugfix
+* [ ] Feature
+* [ ] Code style update (formatting, local variables)
+* [ ] Refactoring (no functional changes, no api changes)
+* [ ] Build related changes
+* [ ] CI related changes
+* [ ] Documentation content changes
+* [ ] Tests
+* [ ] Other
+
+## Backward Compatibility
+
+Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?
+
+* [ ] Yes (backward compatible)
+* [ ] No (breaking changes)
+
+
+## Issue Linking
+<!--
+    KEYWORD #ISSUE-NUMBER
+    [closes|fixes|resolves] #
+-->
+
+## What's new?
+-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   MYSQL_USERNAME: root
   MYSQL_PASSWORD: Password123
   DISABLE_TESTCONTAINERS: true
-  AWS_ACCESS_KEY_ID: dummy_key
+  AWS_ACCESS_KEY_ID: dummykey
   AWS_SECRET_ACCESS_KEY: dummy_secret
   AWS_DEFAULT_REGION: us-west-2
   AWS_REGION: us-west-2


### PR DESCRIPTION
- Add a PR template
- Update CI env variables as per https://repost.aws/articles/ARc4hEkF9CRgOrw8kSMe6CwQ/troubleshooting-the-access-key-id-or-security-token-is-invalid-error-after-upgrading-dynamodb-local-to-version-2-0-or-greater#