### PR TITLE
[csharp referenceapp] migrate to .NET 6.0, update deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
     needs: csharp-app-encryption
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/dotnet/sdk:7.0
+      image: mcr.microsoft.com/dotnet/sdk:6.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
     - name: Checkout the repository
@@ -447,7 +447,6 @@ jobs:
     - name: Build
       run: |
         cd samples/csharp/ReferenceApp
-        ./scripts/install-dotnet-3.1.sh
         ./scripts/clean.sh
         ./scripts/build.sh
 

--- a/samples/csharp/ReferenceApp/ReferenceApp/ReferenceApp.csproj
+++ b/samples/csharp/ReferenceApp/ReferenceApp/ReferenceApp.csproj
@@ -5,7 +5,7 @@
         <Description>CSharp AppEncryption Reference App</Description>
         <AssemblyName>ReferenceApp</AssemblyName>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <!-- NOTE: Version controlled via Directory.Build.props  -->
         <!--<Version></Version>-->
         <RootNamespace>GoDaddy.Asherah.ReferenceApp</RootNamespace>
@@ -18,7 +18,7 @@
         <!-- End of Properties related to NuGet packaging: -->
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="GoDaddy.Asherah.AppEncryption" Version="0.2.9" />
+        <PackageReference Include="GoDaddy.Asherah.AppEncryption" Version="0.2.10" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="MySql.Data" Version="8.0.33" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />


### PR DESCRIPTION
## What's new?
- Migrate ReferenceApp projects to .NET 6.0 (from .NET Core 3.1)
- Upgrade AppEncryption to v0.2.10