### PR TITLE
[Java] Upgrade mysql-connector-java to 8.4.0

### DIFF
--- a/samples/java/reference-app/pom.xml
+++ b/samples/java/reference-app/pom.xml
@@ -113,9 +113,9 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.33</version>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <version>8.4.0</version>
     </dependency>
 
     <dependency>

--- a/server/java/pom.xml
+++ b/server/java/pom.xml
@@ -98,9 +98,9 @@
     </dependency>
 
     <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
-        <version>8.0.33</version>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
+        <version>8.4.0</version>
     </dependency>
 
     <dependency>

--- a/tests/cross-language/java/pom.xml
+++ b/tests/cross-language/java/pom.xml
@@ -32,7 +32,7 @@
     <cucumber.version>6.11.0</cucumber.version>
     <junit.jupiter.version>5.11.4</junit.jupiter.version>
     <hikaricp.version>6.2.1</hikaricp.version>
-    <mysql.connector.version>8.0.30</mysql.connector.version>
+    <mysql.connector.version>8.4.0</mysql.connector.version>
     <checkstyle.config>${project.basedir}/checkstyle.xml</checkstyle.config>
   </properties>
 
@@ -106,8 +106,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
       <version>${mysql.connector.version}</version>
     </dependency>
 


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [x] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)

## What's new?
Upgraded mysql-connector-java to 8.4.0 and updated POM dependency to use [new Maven coordinates](https://blogs.oracle.com/mysql/post/mysql-connectorj-has-new-maven-coordinates)
