### PR TITLE
[csharp cltf] set target framework to net6.0

### DIFF
--- a/tests/cross-language/csharp/Cltf.csproj
+++ b/tests/cross-language/csharp/Cltf.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>GoDaddy.Asherah.Cltf</PackageId>
     <!-- NOTE: Version controlled via Directory.Build.props  -->
     <!--<Version></Version>-->


### PR DESCRIPTION
## What's new?
- Upgrade target framework for the C# cross-language test project from `netcoreapp3.1` to `net6.0`
