### PR TITLE
[csharp appencryption] upgrades deps, bump version

### DIFF
--- a/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
+++ b/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="App.Metrics" Version="4.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
     <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="../Crypto/Crypto.csproj" />

--- a/csharp/AppEncryption/Crypto/Crypto.csproj
+++ b/csharp/AppEncryption/Crypto/Crypto.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
-    <PackageReference Include="GoDaddy.Asherah.Logging" Version="0.1.5" />
-    <PackageReference Include="GoDaddy.Asherah.SecureMemory" Version="0.2.4" />
+    <PackageReference Include="GoDaddy.Asherah.Logging" Version="0.1.6" />
+    <PackageReference Include="GoDaddy.Asherah.SecureMemory" Version="0.2.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/csharp/AppEncryption/Directory.Build.props
+++ b/csharp/AppEncryption/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.10</Version>
+    <Version>0.2.11</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## What's new?
- upgraded dependencies:
  - GoDaddy.Asherah.Logging -> 0.1.6
  - GoDaddy.Asherah.SecureMemory -> 0.2.5
  - System.Text.Json -> 9.0.1
- bump version to 0.2.11