### PR TITLE
[java ci] ignore release branches on push

### DIFF
--- a/.github/workflows/java-appencryption-ci.yml
+++ b/.github/workflows/java-appencryption-ci.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'java/appencryption/**'
       - '.github/workflows/java-appencryption-*'
+    branches-ignore:
+      - 'release-*'
 
 permissions:
   contents: read


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)

## What's new?
- Updated push trigger for "[Java] AppEncryption CI" to ignore release branches.