### PR TITLE
[go cltf] stop using deprecated godog CLI

### DIFF
--- a/.github/workflows/cross-language-validation.yml
+++ b/.github/workflows/cross-language-validation.yml
@@ -210,7 +210,6 @@ jobs:
         run: |
           cd tests/cross-language/go
           go mod edit -replace github.com/godaddy/asherah/go/appencryption=../../../go/appencryption
-          go install github.com/cucumber/godog/cmd/godog@latest
           ./scripts/build.sh
 
       - name: Test

--- a/tests/cross-language/go/decrypt_test.go
+++ b/tests/cross-language/go/decrypt_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"testing"
 
+	"github.com/cucumber/godog"
 	"github.com/godaddy/asherah/go/appencryption"
 	"github.com/godaddy/asherah/go/appencryption/pkg/crypto/aead"
 	"github.com/godaddy/asherah/go/appencryption/pkg/kms"
@@ -91,4 +93,23 @@ func decryptedDataShouldBeEqualTo(payload string) error {
 	}
 
 	return nil
+}
+
+func TestDecryptFeatures(t *testing.T) {
+	opts := godog.Options{
+		Paths:    []string{"../features/decrypt.feature"},
+		Format:   "pretty",
+		TestingT: t,
+	}
+
+	status := godog.TestSuite{
+		Name:                 "decrypt",
+		TestSuiteInitializer: InitializeTestSuite,
+		ScenarioInitializer:  InitializeScenario,
+		Options:              &opts,
+	}.Run()
+
+	if status != 0 {
+		t.Fatal("Non-zero status returned")
+	}
 }

--- a/tests/cross-language/go/encrypt_test.go
+++ b/tests/cross-language/go/encrypt_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"testing"
 
 	"github.com/cucumber/godog"
 	"github.com/go-sql-driver/mysql"
@@ -143,4 +144,23 @@ func connectSQL() error {
 	connection = conn
 
 	return nil
+}
+
+func TestEncryptFeatures(t *testing.T) {
+	opts := godog.Options{
+		Paths:    []string{"../features/encrypt.feature"},
+		Format:   "pretty",
+		TestingT: t,
+	}
+
+	status := godog.TestSuite{
+		Name:                 "encrypt",
+		TestSuiteInitializer: InitializeTestSuite,
+		ScenarioInitializer:  InitializeScenario,
+		Options:              &opts,
+	}.Run()
+
+	if status != 0 {
+		t.Fatal("Non-zero status returned")
+	}
 }

--- a/tests/cross-language/scripts/decrypt_all.sh
+++ b/tests/cross-language/scripts/decrypt_all.sh
@@ -41,7 +41,7 @@ cd ..
 
 cd go
 echo "----------------------Decrypting data using Go--------------------------"
-godog ../features/decrypt.feature
+go test -v -test.run '^TestDecryptFeatures$'
 cd ..
 
 cd sidecar

--- a/tests/cross-language/scripts/encrypt_all.sh
+++ b/tests/cross-language/scripts/encrypt_all.sh
@@ -41,7 +41,7 @@ cd ..
 
 cd go
 echo "----------------------Encrypting payload using Go-----------------------"
-godog ../features/encrypt.feature
+go test -v -test.run '^TestEncryptFeatures$'
 cd ..
 
 cd sidecar


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [x] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)

## What's new?
- added test functions for encrypt/decrypt feature tests
- updated testing scripts, replacing use of `godog` with `go test`
- removed godog installation from "Build the Go project" step
