### PR TITLE
[go cltf] add support for godog commandline flags

### DIFF
--- a/tests/cross-language/go/decrypt_test.go
+++ b/tests/cross-language/go/decrypt_test.go
@@ -96,11 +96,7 @@ func decryptedDataShouldBeEqualTo(payload string) error {
 }
 
 func TestDecryptFeatures(t *testing.T) {
-	opts := godog.Options{
-		Paths:    []string{"../features/decrypt.feature"},
-		Format:   "pretty",
-		TestingT: t,
-	}
+	opts := godogOptsWithDefaults(t, "../features/decrypt.feature")
 
 	status := godog.TestSuite{
 		Name:                 "decrypt",

--- a/tests/cross-language/go/encrypt_test.go
+++ b/tests/cross-language/go/encrypt_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -22,7 +23,12 @@ var (
 	payloadString          string
 	encryptedPayloadString string
 	connection             *sql.DB
+	godogOpts              godog.Options
 )
+
+func init() {
+	godog.BindFlags("godog.", flag.CommandLine, &godogOpts)
+}
 
 func iHave(payload string) error {
 	payloadString = payload
@@ -146,12 +152,24 @@ func connectSQL() error {
 	return nil
 }
 
-func TestEncryptFeatures(t *testing.T) {
-	opts := godog.Options{
-		Paths:    []string{"../features/encrypt.feature"},
-		Format:   "pretty",
-		TestingT: t,
+func godogOptsWithDefaults(t *testing.T, defaultPath string) (opts godog.Options) {
+	opts = godogOpts
+
+	opts.TestingT = t
+
+	if opts.Paths == nil {
+		opts.Paths = []string{defaultPath}
 	}
+
+	if opts.Format == "" {
+		opts.Format = "pretty"
+	}
+
+	return
+}
+
+func TestEncryptFeatures(t *testing.T) {
+	opts := godogOptsWithDefaults(t, "../features/encrypt.feature")
 
 	status := godog.TestSuite{
 		Name:                 "encrypt",
@@ -163,4 +181,9 @@ func TestEncryptFeatures(t *testing.T) {
 	if status != 0 {
 		t.Fatal("Non-zero status returned")
 	}
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
 }

--- a/tests/cross-language/scripts/decrypt_all.sh
+++ b/tests/cross-language/scripts/decrypt_all.sh
@@ -41,7 +41,7 @@ cd ..
 
 cd go
 echo "----------------------Decrypting data using Go--------------------------"
-go test -v -test.run '^TestDecryptFeatures$'
+go test -v -test.run '^TestDecryptFeatures$' -godog.paths=../features/decrypt.feature
 cd ..
 
 cd sidecar

--- a/tests/cross-language/scripts/encrypt_all.sh
+++ b/tests/cross-language/scripts/encrypt_all.sh
@@ -41,7 +41,7 @@ cd ..
 
 cd go
 echo "----------------------Encrypting payload using Go-----------------------"
-go test -v -test.run '^TestEncryptFeatures$'
+go test -v -test.run '^TestEncryptFeatures$' -godog.paths=../features/encrypt.feature
 cd ..
 
 cd sidecar


### PR DESCRIPTION
## What's new?
- Adds support for godog commandline flags
  **NOTE**: This is required to support custom feature paths for downstream projects
