### PR TITLE
[cicd] updated release scripts

### DIFF
--- a/build/csharp/release_prod.sh
+++ b/build/csharp/release_prod.sh
@@ -8,19 +8,14 @@ TAG=`echo csharp/${ARTIFACT_NAME}/v${BASE_VERSION}`
 
 RESULT=$(git tag -l ${TAG})
 if [[ "$RESULT" != ${TAG} ]]; then
-    # START dry run (TODO: Remove)
-    echo "Releasing (DRY RUN): ${ARTIFACT_NAME} v${BASE_VERSION}"
-    echo "Tag: ${TAG}, SHA: ${GITHUB_SHA}"
-    echo "Exiting without pushing changes"
-    exit 0
-    # END dry run
-
+    echo "Releasing: ${ARTIFACT_NAME} v${BASE_VERSION}"
     dotnet pack -c Release
-    echo "Releasing ${ARTIFACT_NAME} artifact"
     find . -name *${BASE_VERSION}.nupkg  | xargs -L1 -I '{}' dotnet nuget push {} -k ${NUGET_KEY} -s ${NUGET_SOURCE}
 
     # Create tag
-    git tag -f ${TAG} ${GITHUB_SHA}
+    PARENT_COMMIT=$(git rev-parse "${GITHUB_SHA}^2")
+    echo "Creating new tag: ${TAG}, SHA: ${PARENT_COMMIT}"
+    git tag -f ${TAG} ${PARENT_COMMIT}
     git push origin --tags
     echo "Created tag ${TAG}"
 else

--- a/build/csharp/release_prod.sh
+++ b/build/csharp/release_prod.sh
@@ -15,7 +15,7 @@ if [[ "$RESULT" != ${TAG} ]]; then
     # Create tag
     PARENT_COMMIT=$(git rev-parse "${GITHUB_SHA}^2")
     echo "Creating new tag: ${TAG}, SHA: ${PARENT_COMMIT}"
-    git tag -f ${TAG} ${PARENT_COMMIT}
+    git tag ${TAG} ${PARENT_COMMIT}
     git push origin --tags
     echo "Created tag ${TAG}"
 else

--- a/build/go/release_prod.sh
+++ b/build/go/release_prod.sh
@@ -7,16 +7,11 @@ TAG=`echo go/${ARTIFACT_NAME}/v${BASE_VERSION}`
 
 RESULT=$(git tag -l ${TAG})
 if [[ "$RESULT" != ${TAG}  ]]; then
-    # START dry run (TODO: Remove)
-    echo "Releasing (DRY RUN): ${ARTIFACT_NAME} v${BASE_VERSION}"
-    echo "Tag: ${TAG}, SHA: ${GITHUB_SHA}"
-    echo "Exiting without pushing changes"
-    exit 0
-    # END dry run
-
     # Create tag
-    echo "Releasing ${ARTIFACT_NAME} artifact"
-    git tag -f ${TAG} ${GITHUB_SHA}
+    PARENT_COMMIT=$(git rev-parse "${GITHUB_SHA}^2")
+    echo "Releasing: ${ARTIFACT_NAME} v${BASE_VERSION}"
+    echo "Creating new tag: ${TAG}, SHA: ${PARENT_COMMIT}"
+    git tag -f ${TAG} ${PARENT_COMMIT}
     git push origin --tags
     echo "Created tag ${TAG}"
 else

--- a/build/go/release_prod.sh
+++ b/build/go/release_prod.sh
@@ -11,7 +11,7 @@ if [[ "$RESULT" != ${TAG}  ]]; then
     PARENT_COMMIT=$(git rev-parse "${GITHUB_SHA}^2")
     echo "Releasing: ${ARTIFACT_NAME} v${BASE_VERSION}"
     echo "Creating new tag: ${TAG}, SHA: ${PARENT_COMMIT}"
-    git tag -f ${TAG} ${PARENT_COMMIT}
+    git tag ${TAG} ${PARENT_COMMIT}
     git push origin --tags
     echo "Created tag ${TAG}"
 else

--- a/build/java/release_prod.sh
+++ b/build/java/release_prod.sh
@@ -14,7 +14,7 @@ if [[ "$RESULT" != ${TAG} ]]; then
     # Create tag
     PARENT_COMMIT=$(git rev-parse "${GITHUB_SHA}^2")
     echo "Creating new tag: ${TAG}, SHA: ${PARENT_COMMIT}"
-    git tag -f ${TAG} ${PARENT_COMMIT}
+    git tag ${TAG} ${PARENT_COMMIT}
     git push origin --tags
     echo "Created tag ${TAG}"
 else

--- a/build/java/release_prod.sh
+++ b/build/java/release_prod.sh
@@ -8,18 +8,13 @@ TAG=`echo java/${ARTIFACT_NAME}/v${BASE_VERSION}`
 
 RESULT=$(git tag -l ${TAG})
 if [[ "$RESULT" != ${TAG} ]]; then
-    # START dry run (TODO: Remove)
-    echo "Releasing (DRY RUN): ${ARTIFACT_NAME} v${BASE_VERSION}"
-    echo "Tag: ${TAG}, SHA: ${GITHUB_SHA}"
-    echo "Exiting without pushing changes"
-    exit 0
-    # END dry run
-
-    echo "Releasing ${ARTIFACT_NAME} artifact"
+    echo "Releasing: ${ARTIFACT_NAME} v${BASE_VERSION}"
     mvn -DskipTests deploy -Prelease
 
     # Create tag
-    git tag -f ${TAG} ${GITHUB_SHA}
+    PARENT_COMMIT=$(git rev-parse "${GITHUB_SHA}^2")
+    echo "Creating new tag: ${TAG}, SHA: ${PARENT_COMMIT}"
+    git tag -f ${TAG} ${PARENT_COMMIT}
     git push origin --tags
     echo "Created tag ${TAG}"
 else


### PR DESCRIPTION
## What's new?
- Removed the "DRY RUN" logging/early exit
- Tags will now be created using the second parent of the merge commit, i.e., the commit from the main branch
- Tags will no longer be created using the `--force` option. If a tag already exists then something has gone wrong and the operation should fail accordingly.