### PR TITLE
[csharp securememory] exception handling updates (fix tests)

### DIFF
--- a/csharp/SecureMemory/Directory.Build.props
+++ b/csharp/SecureMemory/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.2.6</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 </Project>

--- a/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
+++ b/csharp/SecureMemory/SecureMemory.Tests/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorTest.cs
@@ -133,19 +133,21 @@ namespace GoDaddy.Asherah.SecureMemory.Tests.ProtectedMemoryImpl.Libc
             {
                 macOsProtectedMemoryAllocatorMock.Setup(x => x.SetNoDump(It.IsAny<IntPtr>(), It.IsAny<ulong>()))
                     .Throws(new LibcOperationFailedException("IGNORE_INTENTIONAL_ERROR", 1));
-                Assert.Throws<LibcOperationFailedException>(() =>
+                var exception = Assert.Throws<SecureMemoryAllocationFailedException>(() =>
                 {
                     macOsProtectedMemoryAllocatorMock.Object.Alloc(1);
                 });
+                Assert.IsType<LibcOperationFailedException>(exception.InnerException);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 linuxProtectedMemoryAllocatorMock.Setup(x => x.SetNoDump(It.IsAny<IntPtr>(), It.IsAny<ulong>()))
                     .Throws(new LibcOperationFailedException("IGNORE_INTENTIONAL_ERROR", 1));
-                Assert.Throws<LibcOperationFailedException>(() =>
+                var exception = Assert.Throws<SecureMemoryAllocationFailedException>(() =>
                 {
                     linuxProtectedMemoryAllocatorMock.Object.Alloc(1);
                 });
+                Assert.IsType<LibcOperationFailedException>(exception.InnerException);
             }
         }
 

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Libc/LibcProtectedMemoryAllocatorLP64.cs
@@ -57,7 +57,7 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Libc
                 {
                     Check.Zero(GetLibc().munlock(protectedMemory, length), "munlock", e);
                     Interlocked.Add(ref memoryLocked, 0 - (long)length);
-                    throw;
+                    throw new SecureMemoryAllocationFailedException("Failed to set no dump on protected memory", e);
                 }
             }
             catch (Exception e)

--- a/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
+++ b/csharp/SecureMemory/SecureMemory/ProtectedMemoryImpl/Linux/LinuxOpenSSL11ProtectedMemoryAllocatorLP64.cs
@@ -140,10 +140,10 @@ namespace GoDaddy.Asherah.SecureMemory.ProtectedMemoryImpl.Linux
             {
                 SetNoDump(protectedMemory, length);
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 openSSL11.CRYPTO_secure_free(protectedMemory);
-                throw;
+                throw new SecureMemoryAllocationFailedException("Failed to set no dump on protected memory", e);
             }
 
             return protectedMemory;

--- a/csharp/SecureMemory/SecureMemory/SecureMemoryAllocationFailedException.cs
+++ b/csharp/SecureMemory/SecureMemory/SecureMemoryAllocationFailedException.cs
@@ -1,9 +1,16 @@
+using System;
+
 namespace GoDaddy.Asherah.SecureMemory
 {
     public class SecureMemoryAllocationFailedException : SecureMemoryException
     {
         public SecureMemoryAllocationFailedException(string message)
             : base(message)
+        {
+        }
+
+        public SecureMemoryAllocationFailedException(string message, Exception innerException)
+            : base(message, innerException)
         {
         }
     }

--- a/csharp/SecureMemory/SecureMemory/SecureMemoryException.cs
+++ b/csharp/SecureMemory/SecureMemory/SecureMemoryException.cs
@@ -8,5 +8,10 @@ namespace GoDaddy.Asherah.SecureMemory
             : base(message)
         {
         }
+
+        public SecureMemoryException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
     }
 }


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [ ] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## What's new?
This change adds inner exception constructor to SecureMemoryException and SecureMemoryAllocationFailedException classes to enable proper exception chaining. The LibcProtectedMemoryAllocatorLP64 and LinuxOpenSSL11ProtectedMemoryAllocatorLP64 implementations were updated to wrap exceptions from SetNoDump in SecureMemoryAllocationFailedException with appropriate error context. Tests were also updated to verify the new exception wrapping behavior.

