### PR TITLE
[csharp] multi-target framework updates for .net 8.0 and 9.0

### DIFF
--- a/.github/workflows/cross-language-validation.yml
+++ b/.github/workflows/cross-language-validation.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
         with:
           dotnet-version: |
-            6.0.x
+            9.0.x
 
       - name: Set up Go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0

--- a/.github/workflows/csharp-appencryption-ci.yml
+++ b/.github/workflows/csharp-appencryption-ci.yml
@@ -88,7 +88,7 @@ jobs:
       dynamodb:
         image: amazon/dynamodb-local
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: ${{ env.MYSQL_PASSWORD }}
     steps:

--- a/.github/workflows/csharp-appencryption-ci.yml
+++ b/.github/workflows/csharp-appencryption-ci.yml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       artifact: ${{ steps.upload-artifact.outputs.artifact_id }}
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0
+      image: mcr.microsoft.com/dotnet/sdk:9.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
       - name: Checkout repository
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0
+      image: mcr.microsoft.com/dotnet/sdk:9.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     services:
       dynamodb:

--- a/.github/workflows/csharp-appencryption-integration.yml
+++ b/.github/workflows/csharp-appencryption-integration.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/**/*.csproj') }}-v2
+          key: ${{ runner.os }}-nuget-appencryption-${{ hashFiles('csharp/AppEncryption/**/*.csproj') }}-v2
 
       - name: Build AppEncryption
         run: |

--- a/.github/workflows/csharp-appencryption-integration.yml
+++ b/.github/workflows/csharp-appencryption-integration.yml
@@ -23,7 +23,7 @@ jobs:
     name: 'Run Integration Tests'
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0
+      image: mcr.microsoft.com/dotnet/sdk:9.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     services:
       dynamodb:

--- a/.github/workflows/csharp-appencryption-release.yml
+++ b/.github/workflows/csharp-appencryption-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/**/*.csproj') }}-v2
+          key: ${{ runner.os }}-nuget-appencryption-${{ hashFiles('csharp/AppEncryption/**/*.csproj') }}-v2
 
       - name: Download artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/csharp-logging-ci.yml
+++ b/.github/workflows/csharp-logging-ci.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       artifact: ${{ steps.upload-artifact.outputs.artifact_id }}
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0
+      image: mcr.microsoft.com/dotnet/sdk:9.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
       - name: Checkout repository

--- a/.github/workflows/csharp-logging-ci.yml
+++ b/.github/workflows/csharp-logging-ci.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/**/*.csproj') }}-v2
+          key: ${{ runner.os }}-nuget-logging-${{ hashFiles('csharp/Logging/**/*.csproj') }}-v2
 
       - name: Build
         run: |

--- a/.github/workflows/csharp-logging-release.yml
+++ b/.github/workflows/csharp-logging-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/**/*.csproj') }}-v2
+          key: ${{ runner.os }}-nuget-logging-${{ hashFiles('csharp/Logging/**/*.csproj') }}-v2
 
       - name: Download artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/csharp-pr.yml
+++ b/.github/workflows/csharp-pr.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/**/*.csproj') }}-v2
+          key: ${{ runner.os }}-nuget-reference-${{ hashFiles('samples/csharp/ReferenceApp/**/*.csproj') }}-v2
 
       - name: Build
         run: |

--- a/.github/workflows/csharp-pr.yml
+++ b/.github/workflows/csharp-pr.yml
@@ -26,7 +26,7 @@ jobs:
     name: 'Reference App: Build'
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0
+      image: mcr.microsoft.com/dotnet/sdk:9.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
       - name: Checkout repository

--- a/.github/workflows/csharp-securememory-ci.yml
+++ b/.github/workflows/csharp-securememory-ci.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/**/*.csproj') }}-v2
+          key: ${{ runner.os }}-nuget-securememory-${{ hashFiles('csharp/SecureMemory/**/*.csproj') }}-v2
 
       - name: Build
         run: |
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/**/*.csproj') }}-v2
+          key: ${{ runner.os }}-nuget-securememory-${{ hashFiles('csharp/SecureMemory/**/*.csproj') }}-v2
 
       - name: Download artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/csharp-securememory-ci.yml
+++ b/.github/workflows/csharp-securememory-ci.yml
@@ -86,6 +86,12 @@ jobs:
           name: csharp-secure-memory
           path: ${{ github.workspace }}/csharp/SecureMemory
 
+      - name: Install libssl-1.1
+        run: |
+          wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+          dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+          rm libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+
       - name: Run unit tests
         run: |
           cd csharp/SecureMemory

--- a/.github/workflows/csharp-securememory-ci.yml
+++ b/.github/workflows/csharp-securememory-ci.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       artifact: ${{ steps.upload-artifact.outputs.artifact_id }}
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0
+      image: mcr.microsoft.com/dotnet/sdk:9.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
       - name: Checkout repository
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     container:
-      image: mcr.microsoft.com/dotnet/sdk:6.0
+      image: mcr.microsoft.com/dotnet/sdk:9.0
       options: --ulimit core=-1 --ulimit memlock=-1:-1
     steps:
       - name: Checkout repository

--- a/.github/workflows/csharp-securememory-release.yml
+++ b/.github/workflows/csharp-securememory-release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('csharp/**/*.csproj') }}-v2
+          key: ${{ runner.os }}-nuget-securememory-${{ hashFiles('csharp/SecureMemory/**/*.csproj') }}-v2
 
       - name: Download artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/csharp/AppEncryption/AppEncryption.IntegrationTests/AppEncryption.IntegrationTests.csproj
+++ b/csharp/AppEncryption/AppEncryption.IntegrationTests/AppEncryption.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <RootNamespace>GoDaddy.Asherah.AppEncryption.IntegrationTests</RootNamespace>
         <CodeAnalysisRuleSet>../StyleCopCustom.ruleset</CodeAnalysisRuleSet>

--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption.Tests.csproj
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>GoDaddy.Asherah.AppEncryption.Tests</RootNamespace>
     <CodeAnalysisRuleSet>../StyleCopCustom.ruleset</CodeAnalysisRuleSet>

--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/MySqlContainerFixture.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/MySqlContainerFixture.cs
@@ -17,7 +17,7 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Persistence
             if (disableTestContainers)
             {
                 string hostname = Environment.GetEnvironmentVariable("MYSQL_HOSTNAME") ?? "localhost";
-                localConnectionString = $"server={hostname};uid=root;pwd=Password123;sslmode=none";
+                localConnectionString = $"server={hostname};uid=root;pwd=Password123;";
             }
             else
             {

--- a/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
+++ b/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
@@ -5,7 +5,7 @@
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>
     <Description>Application level envelope encryption SDK for C#</Description>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!-- NOTE: Version controlled via Directory.Build.props  -->

--- a/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
+++ b/csharp/AppEncryption/AppEncryption/AppEncryption.csproj
@@ -5,7 +5,7 @@
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>
     <Description>Application level envelope encryption SDK for C#</Description>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!-- NOTE: Version controlled via Directory.Build.props  -->

--- a/csharp/AppEncryption/Crypto/Crypto.csproj
+++ b/csharp/AppEncryption/Crypto/Crypto.csproj
@@ -3,7 +3,7 @@
     <PackageId>GoDaddy.Asherah.Crypto</PackageId>
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!-- NOTE: Version controlled via Directory.Build.props  -->

--- a/csharp/AppEncryption/Crypto/Crypto.csproj
+++ b/csharp/AppEncryption/Crypto/Crypto.csproj
@@ -3,7 +3,7 @@
     <PackageId>GoDaddy.Asherah.Crypto</PackageId>
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!-- NOTE: Version controlled via Directory.Build.props  -->

--- a/csharp/Logging/Logging.Tests/Logging.Tests.csproj
+++ b/csharp/Logging/Logging.Tests/Logging.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>GoDaddy.Asherah.Logging.Tests</RootNamespace>
     <CodeAnalysisRuleSet>../StyleCopCustom.ruleset</CodeAnalysisRuleSet>

--- a/csharp/Logging/Logging/Logging.csproj
+++ b/csharp/Logging/Logging/Logging.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <PackageId>GoDaddy.Asherah.Logging</PackageId>
     <Title>Logging</Title>
     <Authors>GoDaddy</Authors>

--- a/csharp/Logging/Logging/Logging.csproj
+++ b/csharp/Logging/Logging/Logging.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <PackageId>GoDaddy.Asherah.Logging</PackageId>
     <Title>Logging</Title>
     <Authors>GoDaddy</Authors>

--- a/csharp/SecureMemory/PlatformNative/PlatformNative.csproj
+++ b/csharp/SecureMemory/PlatformNative/PlatformNative.csproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <PackageId>GoDaddy.Asherah.PlatformNative</PackageId>
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>GoDaddy.Asherah.PlatformNative</RootNamespace>
     <CodeAnalysisRuleSet>../StyleCopCustom.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- CS8981 is a warning for using a type name that only contains lowercase letters. -->
+    <!-- This naming convention is used for native libraries, so we suppress the warning. -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/godaddy/asherah</PackageProjectUrl>
     <RepositoryUrl>https://github.com/godaddy/asherah/tree/main/csharp/SecureMemory/PlatformNative</RepositoryUrl>

--- a/csharp/SecureMemory/PlatformNative/PlatformNative.csproj
+++ b/csharp/SecureMemory/PlatformNative/PlatformNative.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <PackageId>GoDaddy.Asherah.PlatformNative</PackageId>
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>

--- a/csharp/SecureMemory/SecureMemory.Tests/SecureMemory.Tests.csproj
+++ b/csharp/SecureMemory/SecureMemory.Tests/SecureMemory.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>GoDaddy.Asherah.SecureMemory.Tests</RootNamespace>
     <CodeAnalysisRuleSet>../StyleCopCustom.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/csharp/SecureMemory/SecureMemory/SecureMemory.csproj
+++ b/csharp/SecureMemory/SecureMemory/SecureMemory.csproj
@@ -6,7 +6,7 @@
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>
     <Description>Provides a secure area of memory to store sensitive data</Description>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>GoDaddy.Asherah.SecureMemory</RootNamespace>
     <CodeAnalysisRuleSet>../StyleCopCustom.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/csharp/SecureMemory/SecureMemory/SecureMemory.csproj
+++ b/csharp/SecureMemory/SecureMemory/SecureMemory.csproj
@@ -6,7 +6,7 @@
     <Authors>GoDaddy</Authors>
     <Company>GoDaddy</Company>
     <Description>Provides a secure area of memory to store sensitive data</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>GoDaddy.Asherah.SecureMemory</RootNamespace>
     <CodeAnalysisRuleSet>../StyleCopCustom.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/samples/csharp/ReferenceApp/ReferenceApp/ReferenceApp.csproj
+++ b/samples/csharp/ReferenceApp/ReferenceApp/ReferenceApp.csproj
@@ -5,7 +5,7 @@
         <Description>CSharp AppEncryption Reference App</Description>
         <AssemblyName>ReferenceApp</AssemblyName>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <!-- NOTE: Version controlled via Directory.Build.props  -->
         <!--<Version></Version>-->
         <RootNamespace>GoDaddy.Asherah.ReferenceApp</RootNamespace>

--- a/tests/cross-language/csharp/Cltf.csproj
+++ b/tests/cross-language/csharp/Cltf.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageId>GoDaddy.Asherah.Cltf</PackageId>
     <!-- NOTE: Version controlled via Directory.Build.props  -->
     <!--<Version></Version>-->


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
Resolves #1183

## What's new?
- Added multi-target framework support for all C# projects to target net8.0 and net9.0
- Dropped support for netstandard2.1
- Test projects updated to target net9.0
- Updated CI/CD workflows:
  - Updated cache keys for C# projects to be more specific and granular
  - Use .NET 9.0 SDK container images
  - [AppEncryption CI] Added MySQL 8.0 support and fixed connection string configuration
  - [SecureMemory CI] Added libssl installation step to fix runtime dependencies

These changes modernize the C# libraries to support the latest .NET frameworks while maintaining backward compatibility, ensuring the code can run on newer platforms.
