### PR TITLE
[csharp] Add .NET 9.0 setup to C# release workflows

### DIFF
--- a/.github/workflows/csharp-appencryption-release.yml
+++ b/.github/workflows/csharp-appencryption-release.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Set up C#
+        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
+        with:
+          dotnet-version: |
+            9.0.x
+
       - name: Fetch all tags
         run: git fetch --prune --unshallow --tags
 

--- a/.github/workflows/csharp-logging-release.yml
+++ b/.github/workflows/csharp-logging-release.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Set up C#
+        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
+        with:
+          dotnet-version: |
+            9.0.x
+
       - name: Fetch all tags
         run: git fetch --prune --unshallow --tags
 

--- a/.github/workflows/csharp-securememory-release.yml
+++ b/.github/workflows/csharp-securememory-release.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Set up C#
+        uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
+        with:
+          dotnet-version: |
+            9.0.x
+
       - name: Fetch all tags
         run: git fetch --prune --unshallow --tags
 


### PR DESCRIPTION
Add actions/setup-dotnet step with .NET 9.0 to all three C# release workflows to ensure proper build environment after dropping multi-target framework support.

