### PR TITLE
[ci] bump actions/setup-go to v5.5.0 and actions/setup-java to v4.7.1

### DIFF
--- a/.github/workflows/cross-language-validation.yml
+++ b/.github/workflows/cross-language-validation.yml
@@ -96,7 +96,7 @@ jobs:
           cache-dependency-path: 'java/*/pom.xml'
 
       - name: Set up Python
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -157,7 +157,7 @@ jobs:
           cache-dependency-path: 'java/*/pom.xml'
 
       - name: Set up Python
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
           cache: 'pip'

--- a/.github/workflows/cross-language-validation.yml
+++ b/.github/workflows/cross-language-validation.yml
@@ -88,7 +88,7 @@ jobs:
           cache-dependency-path: 'go/*/go.sum'
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ needs.init-defaults.outputs.java-version }}
           distribution: 'temurin'
@@ -149,7 +149,7 @@ jobs:
           cache-dependency-path: 'go/*/go.sum'
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ needs.init-defaults.outputs.java-version }}
           distribution: 'temurin'

--- a/.github/workflows/cross-language-validation.yml
+++ b/.github/workflows/cross-language-validation.yml
@@ -82,7 +82,7 @@ jobs:
           sudo apt-get install -y build-essential
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.init-defaults.outputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'
@@ -143,7 +143,7 @@ jobs:
             9.0.x
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.init-defaults.outputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'

--- a/.github/workflows/go-appencryption-bench.yml
+++ b/.github/workflows/go-appencryption-bench.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ inputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'

--- a/.github/workflows/go-appencryption-ci.yml
+++ b/.github/workflows/go-appencryption-ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.init-defaults.outputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.init-defaults.outputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'

--- a/.github/workflows/go-appencryption-integration.yml
+++ b/.github/workflows/go-appencryption-integration.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ inputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'

--- a/.github/workflows/go-pr.yml
+++ b/.github/workflows/go-pr.yml
@@ -61,7 +61,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: stable
           cache-dependency-path: |
@@ -97,7 +97,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: stable
           cache-dependency-path: |

--- a/.github/workflows/go-securememory-bench.yml
+++ b/.github/workflows/go-securememory-bench.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ inputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'

--- a/.github/workflows/go-securememory-ci.yml
+++ b/.github/workflows/go-securememory-ci.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.init-defaults.outputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.init-defaults.outputs.go-version }}
           cache-dependency-path: 'go/*/go.sum'

--- a/.github/workflows/java-appencryption-ci.yml
+++ b/.github/workflows/java-appencryption-ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ needs.init-defaults.outputs.java-version }}
           distribution: 'temurin'
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ needs.init-defaults.outputs.java-version }}
           distribution: 'temurin'

--- a/.github/workflows/java-appencryption-integration.yml
+++ b/.github/workflows/java-appencryption-integration.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ inputs.java-version }}
           distribution: 'temurin'

--- a/.github/workflows/java-appencryption-release.yml
+++ b/.github/workflows/java-appencryption-release.yml
@@ -23,7 +23,7 @@ jobs:
         run: git fetch --prune --unshallow --tags
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@ddb82ce8a6ecf5ac3e80c3184839e6661546e4aa
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/java-securememory-ci.yml
+++ b/.github/workflows/java-securememory-ci.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ needs.init-defaults.outputs.java-version }}
           distribution: 'temurin'
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Set up Java
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ needs.init-defaults.outputs.java-version }}
           distribution: 'temurin'

--- a/.github/workflows/java-securememory-release.yml
+++ b/.github/workflows/java-securememory-release.yml
@@ -23,7 +23,7 @@ jobs:
         run: git fetch --prune --unshallow --tags
 
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@ddb82ce8a6ecf5ac3e80c3184839e6661546e4aa
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: '17'
           distribution: 'temurin'


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [x] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)

## What's new?
- bump actions/setup-java from 4.2.1 to 4.7.1
- bump actions/setup-go from 5.2.0 to 5.5.0
- bump actions/setup-python from 5.1.1 to 5.6.0
