### PR TITLE
[csharp appencryption] upgrade deps, bump version

### DIFF
--- a/csharp/AppEncryption/Crypto/Crypto.csproj
+++ b/csharp/AppEncryption/Crypto/Crypto.csproj
@@ -22,8 +22,8 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
-    <PackageReference Include="GoDaddy.Asherah.Logging" Version="0.2.0" />
-    <PackageReference Include="GoDaddy.Asherah.SecureMemory" Version="0.3.0" />
+    <PackageReference Include="GoDaddy.Asherah.Logging" Version="0.3.0" />
+    <PackageReference Include="GoDaddy.Asherah.SecureMemory" Version="0.4.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="9.0.7" />
     <PackageReference Include="System.Text.Json" Version="9.0.7" />
   </ItemGroup>

--- a/csharp/AppEncryption/Directory.Build.props
+++ b/csharp/AppEncryption/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.5.0</Version>
+    <Version>0.6.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## What's new?
- Upgrade GoDaddy.Asherah.Logging to v0.3.0
- Upgrade GoDaddy.Asherah.SecureMemory to v0.4.0
- Bump version to 0.6.0
