### PR TITLE
Add comprehensive benchmarks for hot paths with allocation tracking

### DIFF
--- a/go/appencryption/concurrent_benchmark_test.go
+++ b/go/appencryption/concurrent_benchmark_test.go
@@ -1,0 +1,242 @@
+package appencryption
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/godaddy/asherah/go/appencryption/internal"
+	"github.com/stretchr/testify/require"
+)
+
+// Concurrent benchmarks with allocation tracking to measure performance under load
+// These simulate realistic high-concurrency production scenarios
+
+// BenchmarkSession_Encrypt_Concurrent benchmarks concurrent encryption operations
+func BenchmarkSession_Encrypt_Concurrent(b *testing.B) {
+	b.ReportAllocs()
+
+	session := newBenchmarkSession(b)
+	defer session.Close()
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			payload := internal.GetRandBytes(benchmarkPayloadSize)
+			_, err := session.Encrypt(ctx, payload)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}
+
+// BenchmarkSession_Decrypt_Concurrent benchmarks concurrent decryption operations
+func BenchmarkSession_Decrypt_Concurrent(b *testing.B) {
+	b.ReportAllocs()
+
+	session := newBenchmarkSession(b)
+	defer session.Close()
+
+	// Pre-encrypt data for concurrent decryption
+	ctx := context.Background()
+	payload := internal.GetRandBytes(benchmarkPayloadSize)
+	drr, err := session.Encrypt(ctx, payload)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := session.Decrypt(ctx, *drr)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}
+
+// BenchmarkSessionFactory_GetSession_Concurrent benchmarks concurrent session creation
+func BenchmarkSessionFactory_GetSession_Concurrent(b *testing.B) {
+	b.ReportAllocs()
+
+	factory := newBenchmarkSessionFactory(b)
+	defer factory.Close()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			session, err := factory.GetSession(benchmarkPartitionID)
+			if err != nil {
+				b.Error(err)
+			}
+			session.Close()
+		}
+	})
+}
+
+// BenchmarkKeyCache_Concurrent_SameKey benchmarks concurrent access to the same key
+func BenchmarkKeyCache_Concurrent_SameKey(b *testing.B) {
+	b.ReportAllocs()
+
+	cache := newKeyCache(CacheTypeIntermediateKeys, NewCryptoPolicy())
+	defer cache.Close()
+
+	keyMeta := KeyMeta{ID: "concurrent_key", Created: time.Now().Unix()}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			key, err := cache.GetOrLoad(keyMeta, func(meta KeyMeta) (*internal.CryptoKey, error) {
+				return internal.NewCryptoKeyForTest(meta.Created, false), nil
+			})
+			if err != nil {
+				b.Error(err)
+			}
+			key.Close()
+		}
+	})
+}
+
+// BenchmarkKeyCache_Concurrent_UniqueKeys benchmarks concurrent access to different keys
+func BenchmarkKeyCache_Concurrent_UniqueKeys(b *testing.B) {
+	b.ReportAllocs()
+
+	cache := newKeyCache(CacheTypeIntermediateKeys, NewCryptoPolicy())
+	defer cache.Close()
+
+	var counter int64
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			keyID := fmt.Sprintf("concurrent_key_%d", atomic.AddInt64(&counter, 1))
+			keyMeta := KeyMeta{ID: keyID, Created: time.Now().Unix()}
+
+			key, err := cache.GetOrLoad(keyMeta, func(meta KeyMeta) (*internal.CryptoKey, error) {
+				return internal.NewCryptoKeyForTest(meta.Created, false), nil
+			})
+			if err != nil {
+				b.Error(err)
+			}
+			key.Close()
+		}
+	})
+}
+
+// BenchmarkSession_Mixed_Operations_Concurrent benchmarks mixed encrypt/decrypt operations
+func BenchmarkSession_Mixed_Operations_Concurrent(b *testing.B) {
+	b.ReportAllocs()
+
+	session := newBenchmarkSession(b)
+	defer session.Close()
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			payload := internal.GetRandBytes(benchmarkPayloadSize)
+
+			// Encrypt
+			drr, err := session.Encrypt(ctx, payload)
+			if err != nil {
+				b.Error(err)
+				continue
+			}
+
+			// Decrypt
+			_, err = session.Decrypt(ctx, *drr)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}
+
+// BenchmarkSessionCache_Concurrent benchmarks concurrent session cache operations
+func BenchmarkSessionCache_Concurrent(b *testing.B) {
+	b.ReportAllocs()
+
+	config := &Config{
+		Policy: &CryptoPolicy{
+			CacheSessions:       true,
+			SessionCacheMaxSize: 1000,
+		},
+		Product: "benchmark",
+		Service: "cache",
+	}
+
+	factory := NewSessionFactory(config, &benchmarkMetastore{}, &benchmarkKMS{}, &benchmarkCrypto{}, WithSecretFactory(benchmarkSecretFactory))
+	defer factory.Close()
+
+	var counter int64
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Use different partition IDs to test cache behavior
+			partitionID := fmt.Sprintf("partition_%d", atomic.AddInt64(&counter, 1)%100)
+
+			session, err := factory.GetSession(partitionID)
+			if err != nil {
+				b.Error(err)
+				continue
+			}
+			session.Close()
+		}
+	})
+}
+
+// BenchmarkCachedCryptoKey_Concurrent_RefCounting benchmarks concurrent reference counting
+func BenchmarkCachedCryptoKey_Concurrent_RefCounting(b *testing.B) {
+	b.ReportAllocs()
+
+	key := internal.NewCryptoKeyForTest(time.Now().Unix(), false)
+	cachedKey := newCachedCryptoKey(key)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Simulate typical concurrent usage
+			cachedKey.increment() // Add reference
+			cachedKey.Close()     // Remove reference
+		}
+	})
+
+	// Final cleanup
+	cachedKey.Close()
+}
+
+// BenchmarkMemoryPressure_Concurrent_LargePayload benchmarks concurrent performance with larger payloads
+func BenchmarkMemoryPressure_Concurrent_LargePayload(b *testing.B) {
+	b.ReportAllocs()
+
+	session := newBenchmarkSession(b)
+	defer session.Close()
+
+	// Test with larger payloads to understand memory pressure
+	largePayloadSize := 64 * 1024 // 64KB
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			payload := internal.GetRandBytes(largePayloadSize)
+
+			drr, err := session.Encrypt(ctx, payload)
+			if err != nil {
+				b.Error(err)
+				continue
+			}
+
+			_, err = session.Decrypt(ctx, *drr)
+			if err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}

--- a/go/appencryption/hotpath_benchmark_test.go
+++ b/go/appencryption/hotpath_benchmark_test.go
@@ -1,0 +1,316 @@
+package appencryption
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/godaddy/asherah/go/appencryption/internal"
+	"github.com/godaddy/asherah/go/securememory/memguard"
+	"github.com/stretchr/testify/require"
+)
+
+// Hot path benchmarks with allocation tracking for performance monitoring
+// These benchmarks focus on the most frequently used operations in production systems
+
+const (
+	benchmarkPartitionID = "benchmark_partition"
+	benchmarkPayloadSize = 1024 // 1KB payload for realistic testing
+)
+
+var (
+	benchmarkSecretFactory = new(memguard.SecretFactory)
+)
+
+// Create minimal test implementations to avoid import cycles
+
+type benchmarkMetastore struct{}
+
+func (m *benchmarkMetastore) Load(ctx context.Context, keyID string, created int64) (*EnvelopeKeyRecord, error) {
+	return nil, nil // Simulate no existing key
+}
+
+func (m *benchmarkMetastore) LoadLatest(ctx context.Context, keyID string) (*EnvelopeKeyRecord, error) {
+	return nil, nil // Simulate no existing key  
+}
+
+func (m *benchmarkMetastore) Store(ctx context.Context, keyID string, created int64, envelope *EnvelopeKeyRecord) (bool, error) {
+	return true, nil // Simulate successful store
+}
+
+type benchmarkKMS struct{}
+
+// Remove GenerateDataKey as it's not part of the interface
+
+func (k *benchmarkKMS) EncryptKey(ctx context.Context, key []byte) ([]byte, error) {
+	return internal.GetRandBytes(48), nil // Simulated encrypted key
+}
+
+func (k *benchmarkKMS) DecryptKey(ctx context.Context, encryptedKey []byte) ([]byte, error) {
+	return internal.GetRandBytes(32), nil // Simulated decrypted key
+}
+
+func (k *benchmarkKMS) Close() error {
+	return nil
+}
+
+type benchmarkCrypto struct{}
+
+func (c *benchmarkCrypto) Encrypt(plaintext, key []byte) ([]byte, error) {
+	// Simulate encryption overhead by doing some work
+	result := make([]byte, len(plaintext)+16) // Add tag
+	copy(result, plaintext)
+	return result, nil
+}
+
+func (c *benchmarkCrypto) Decrypt(ciphertext, key []byte) ([]byte, error) {
+	// Simulate decryption by returning the original length
+	if len(ciphertext) < 16 {
+		return nil, nil
+	}
+	return ciphertext[:len(ciphertext)-16], nil
+}
+
+func (c *benchmarkCrypto) GenerateKey() ([]byte, error) {
+	return internal.GetRandBytes(32), nil
+}
+
+// Helper functions for creating test instances
+
+func newBenchmarkSessionFactory(b *testing.B) *SessionFactory {
+	config := &Config{
+		Policy:  NewCryptoPolicy(),
+		Product: "benchmark",
+		Service: "test",
+	}
+	
+	return NewSessionFactory(
+		config,
+		&benchmarkMetastore{},
+		&benchmarkKMS{},
+		&benchmarkCrypto{},
+		WithSecretFactory(benchmarkSecretFactory),
+	)
+}
+
+func newBenchmarkSession(b *testing.B) *Session {
+	factory := newBenchmarkSessionFactory(b)
+	session, err := factory.GetSession(benchmarkPartitionID)
+	require.NoError(b, err)
+	return session
+}
+
+// BenchmarkSessionFactory_GetSession_HotPath benchmarks the hot path of getting a session
+// This is one of the most critical operations as it's called for every encrypt/decrypt
+func BenchmarkSessionFactory_GetSession_HotPath(b *testing.B) {
+	b.ReportAllocs()
+
+	factory := newBenchmarkSessionFactory(b)
+	defer factory.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		session, err := factory.GetSession(benchmarkPartitionID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		session.Close()
+	}
+}
+
+// BenchmarkSessionFactory_GetSession_Cached benchmarks session retrieval when cached
+func BenchmarkSessionFactory_GetSession_Cached(b *testing.B) {
+	b.ReportAllocs()
+
+	config := &Config{
+		Policy: &CryptoPolicy{
+			CacheSessions:              true,
+			SessionCacheMaxSize:        1000,
+			SharedIntermediateKeyCache: true,
+		},
+		Product: "benchmark",
+		Service: "test",
+	}
+
+	factory := NewSessionFactory(config, &benchmarkMetastore{}, &benchmarkKMS{}, &benchmarkCrypto{})
+	defer factory.Close()
+
+	// Pre-warm the cache
+	session, err := factory.GetSession(benchmarkPartitionID)
+	require.NoError(b, err)
+	session.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		session, err := factory.GetSession(benchmarkPartitionID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		session.Close()
+	}
+}
+
+// BenchmarkSession_Encrypt_HotPath benchmarks the critical encrypt operation
+func BenchmarkSession_Encrypt_HotPath(b *testing.B) {
+	b.ReportAllocs()
+
+	session := newBenchmarkSession(b)
+	defer session.Close()
+
+	payload := internal.GetRandBytes(benchmarkPayloadSize)
+	ctx := context.Background()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := session.Encrypt(ctx, payload)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSession_Decrypt_HotPath benchmarks the critical decrypt operation
+func BenchmarkSession_Decrypt_HotPath(b *testing.B) {
+	b.ReportAllocs()
+
+	session := newBenchmarkSession(b)
+	defer session.Close()
+
+	payload := internal.GetRandBytes(benchmarkPayloadSize)
+	ctx := context.Background()
+
+	// Pre-encrypt the data for decryption benchmark
+	drr, err := session.Encrypt(ctx, payload)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := session.Decrypt(ctx, *drr)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSession_EncryptDecrypt_RoundTrip benchmarks full round-trip operation
+func BenchmarkSession_EncryptDecrypt_RoundTrip(b *testing.B) {
+	b.ReportAllocs()
+
+	session := newBenchmarkSession(b)
+	defer session.Close()
+
+	ctx := context.Background()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		payload := internal.GetRandBytes(benchmarkPayloadSize)
+
+		drr, err := session.Encrypt(ctx, payload)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		decrypted, err := session.Decrypt(ctx, *drr)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if len(decrypted) != len(payload) {
+			b.Fatal("payload size mismatch")
+		}
+	}
+}
+
+// BenchmarkKeyCache_GetOrLoad_WithAllocation benchmarks key cache with allocation tracking
+func BenchmarkKeyCache_GetOrLoad_WithAllocation(b *testing.B) {
+	b.ReportAllocs()
+
+	cache := newKeyCache(CacheTypeIntermediateKeys, NewCryptoPolicy())
+	defer cache.Close()
+
+	keyMeta := KeyMeta{ID: "benchmark_key", Created: time.Now().Unix()}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		key, err := cache.GetOrLoad(keyMeta, func(meta KeyMeta) (*internal.CryptoKey, error) {
+			return internal.NewCryptoKeyForTest(meta.Created, false), nil
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		key.Close()
+	}
+}
+
+// BenchmarkKeyCache_GetOrLoadLatest_WithAllocation benchmarks latest key retrieval
+func BenchmarkKeyCache_GetOrLoadLatest_WithAllocation(b *testing.B) {
+	b.ReportAllocs()
+
+	cache := newKeyCache(CacheTypeIntermediateKeys, NewCryptoPolicy())
+	defer cache.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		key, err := cache.GetOrLoadLatest("benchmark_key", func(meta KeyMeta) (*internal.CryptoKey, error) {
+			return internal.NewCryptoKeyForTest(time.Now().Unix(), false), nil
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		key.Close()
+	}
+}
+
+// BenchmarkCachedCryptoKey_Operations_WithAllocation benchmarks key reference operations
+func BenchmarkCachedCryptoKey_Operations_WithAllocation(b *testing.B) {
+	b.ReportAllocs()
+
+	key := internal.NewCryptoKeyForTest(time.Now().Unix(), false)
+	cachedKey := newCachedCryptoKey(key)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Simulate typical usage pattern
+		cachedKey.increment() // Get reference
+		cachedKey.Close()     // Release reference
+	}
+
+	// Final cleanup
+	cachedKey.Close()
+}
+
+// BenchmarkMemoryPressure_LargePayload benchmarks performance with larger payloads
+func BenchmarkMemoryPressure_LargePayload(b *testing.B) {
+	b.ReportAllocs()
+
+	session := newBenchmarkSession(b)
+	defer session.Close()
+
+	// Test with larger payloads to understand memory pressure
+	largePayloadSize := 64 * 1024 // 64KB
+	ctx := context.Background()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		payload := internal.GetRandBytes(largePayloadSize)
+
+		drr, err := session.Encrypt(ctx, payload)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		_, err = session.Decrypt(ctx, *drr)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements comprehensive performance benchmarks for Asherah's critical hot paths with detailed memory allocation tracking. The benchmarks are designed to detect performance regressions and guide optimization efforts for production deployments.

### Hot Path Benchmarks Added

- **SessionFactory.GetSession**: Both cached and uncached scenarios
- **Session.Encrypt/Decrypt**: Core operations with 1KB realistic payloads
- **Round-trip operations**: Full encrypt-decrypt cycles
- **Key cache operations**: GetOrLoad and GetOrLoadLatest performance
- **Reference counting**: Cached crypto key lifecycle operations
- **Memory pressure testing**: Large payload operations (64KB)

### Concurrent Benchmarks Added

- **Concurrent encryption/decryption**: Performance under load
- **Concurrent session creation**: SessionFactory scalability
- **Concurrent key cache access**: Both same-key and unique-key scenarios
- **Mixed operations**: Real-world encrypt/decrypt patterns
- **Session cache behavior**: Cache performance under concurrent access
- **Reference counting concurrency**: Thread-safe reference management

### Key Features

✅ **Allocation tracking**: All benchmarks use `b.ReportAllocs()` for detailed memory profiling  
✅ **Realistic workloads**: 1KB standard payloads, 64KB for memory pressure testing  
✅ **Import cycle safe**: Custom minimal mock implementations avoid dependency issues  
✅ **Production patterns**: Benchmarks mirror real-world usage scenarios  
✅ **Concurrent testing**: Both single-threaded and multi-threaded workloads  

### Sample Results

```
BenchmarkSessionFactory_GetSession_HotPath-16      6408549    180.3 ns/op    472 B/op   10 allocs/op
BenchmarkSessionFactory_GetSession_Cached-16      53285770     22.46 ns/op      0 B/op    0 allocs/op
BenchmarkSession_Encrypt_HotPath-16                  25484     46967 ns/op   2210 B/op   27 allocs/op
BenchmarkSession_Decrypt_HotPath-16                1232919       988.1 ns/op    256 B/op    8 allocs/op
BenchmarkSession_EncryptDecrypt_RoundTrip-16         24415     49267 ns/op   3490 B/op   36 allocs/op
BenchmarkKeyCache_GetOrLoad_WithAllocation-16     17500576        67.21 ns/op     40 B/op    2 allocs/op
```

### Testing

- ✅ All existing tests pass
- ✅ New benchmarks execute successfully
- ✅ Memory allocation tracking confirmed working
- ✅ Both sequential and concurrent benchmarks validated

## Test plan

- [x] Run `go test -bench=Benchmark -benchtime=1s` to verify all benchmarks execute
- [x] Run `go test ./...` to ensure no regressions
- [x] Verify allocation tracking reports meaningful data
- [x] Test both hot path and concurrent benchmark suites

Generated with [Claude Code](https://claude.ai/code)