### PR TITLE
Suppress aws-sdk-go deprecation warnings in aws-v1 plugins

### DIFF
--- a/go/appencryption/.golangci.yml
+++ b/go/appencryption/.golangci.yml
@@ -134,3 +134,7 @@ issues:
         - godot
         - gosec
         - perfsprint
+    - path: plugins/aws-v1/
+      linters:
+        - staticcheck
+      text: "SA1019.*aws-sdk-go.*deprecated"


### PR DESCRIPTION
## What's new?
- Add lint exclusion rule to suppress SA1019 deprecation warnings for aws-sdk-go in plugins/aws-v1 directory. This maintains backward compatibility during user migration to aws-v2 plugins while allowing CI to pass.
