### PR TITLE
[go appencryption] Update AWS SDK v1 deprecation comments with EOL context

### DIFF
--- a/go/appencryption/.golangci.yml
+++ b/go/appencryption/.golangci.yml
@@ -138,3 +138,7 @@ issues:
       linters:
         - staticcheck
       text: "SA1019.*aws-sdk-go.*deprecated"
+    - path: pkg/(kms|persistence)/
+      linters:
+        - staticcheck
+      text: "SA1019.*is deprecated.*AWS SDK v1 reached end-of-life"

--- a/go/appencryption/pkg/kms/aws.go
+++ b/go/appencryption/pkg/kms/aws.go
@@ -15,25 +15,25 @@ var (
 // KMS is implemented by the client in the kms package from the AWS SDK.
 // We only use a subset of methods defined below.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/kms.KMS instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v2/kms instead.
 type KMS = awsV1kms.KMS
 
 // AWSKMSClient contains a KMS client and region information used for
 // encrypting a key in KMS.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/kms.AWSKMSClient instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v2/kms instead.
 type AWSKMSClient = awsV1kms.AWSKMSClient
 
 // AWSKMS implements the KeyManagementService interface and handles
 // encryption/decryption in KMS.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/kms.AWSKMS instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v2/kms instead.
 type AWSKMS = awsV1kms.AWSKMS
 
 // NewAWS returns a new AWSKMS used for encrypting/decrypting
 // keys with a master key.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/kms.NewAWS instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v2/kms instead.
 func NewAWS(crypto appencryption.AEAD, preferredRegion string, arnMap map[string]string) (*AWSKMS, error) {
 	return awsV1kms.NewAWS(crypto, preferredRegion, arnMap)
 }

--- a/go/appencryption/pkg/persistence/dynamodb.go
+++ b/go/appencryption/pkg/persistence/dynamodb.go
@@ -8,26 +8,26 @@ import (
 
 // DynamoDBMetastore implements the Metastore interface.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/persistence.DynamoDBMetastore instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 type DynamoDBMetastore = awsV1Persistence.DynamoDBMetastore
 
 // DynamoDBMetastoreOption is used to configure additional options in a DynamoDBMetastore.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/persistence.DynamoDBMetastoreOption instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 type DynamoDBMetastoreOption = awsV1Persistence.DynamoDBMetastoreOption
 
 // WithDynamoDBRegionSuffix configures the DynamoDBMetastore to use a regional suffix for
 // all writes. This feature should be enabled when using DynamoDB global tables to avoid
 // write conflicts arising from the "last writer wins" method of conflict resolution.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/persistence.WithDynamoDBRegionSuffix instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 func WithDynamoDBRegionSuffix(enabled bool) DynamoDBMetastoreOption {
 	return awsV1Persistence.WithDynamoDBRegionSuffix(enabled)
 }
 
 // WithTableName configures the DynamoDBMetastore to use the specified table name.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/persistence.WithTableName instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 func WithTableName(table string) DynamoDBMetastoreOption {
 	return awsV1Persistence.WithTableName(table)
 }
@@ -36,19 +36,19 @@ type DynamoDBClientAPI = awsV1Persistence.DynamoDBClientAPI
 
 // WithClient configures the DynamoDBMetastore to use the specified DynamoDB client.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/persistence.WithClient instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 func WithClient(c DynamoDBClientAPI) DynamoDBMetastoreOption {
 	return awsV1Persistence.WithClient(c)
 }
 
 // NewDynamoDBMetastore returns a new DynamoDBMetastore.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/persistence.NewDynamoDBMetastore instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 func NewDynamoDBMetastore(sess awsV1Persistence.ConfigProvider, opts ...DynamoDBMetastoreOption) *DynamoDBMetastore {
 	return awsV1Persistence.NewDynamoDBMetastore(sess, opts...)
 }
 
 // DynamoDBEnvelope is used to convert the EncryptedKey to a Base64 encoded string to save in DynamoDB.
 //
-// Deprecated: Use github.com/godaddy/asherah/go/appencryption/plugins/aws-v1/persistence.DynamoDBEnvelope instead.
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 type DynamoDBEnvelope = awsV1Persistence.DynamoDBEnvelope

--- a/go/appencryption/plugins/aws-v1/kms/aws.go
+++ b/go/appencryption/plugins/aws-v1/kms/aws.go
@@ -44,6 +44,8 @@ type KMS interface {
 
 // AWSKMSClient contains a KMS client and region information used for
 // encrypting a key in KMS.
+//
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/kms instead.
 type AWSKMSClient struct {
 	KMS    KMS
 	Region string
@@ -77,6 +79,8 @@ func createAWSKMSClients(arnMap map[string]string) ([]AWSKMSClient, error) {
 
 // AWSKMS implements the KeyManagementService interface and handles
 // encryption/decryption in KMS.
+//
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/kms instead.
 type AWSKMS struct {
 	Crypto   appencryption.AEAD
 	Clients  []AWSKMSClient
@@ -93,6 +97,8 @@ func sortClients(preferredRegion string, clients []AWSKMSClient) []AWSKMSClient 
 
 // NewAWS returns a new AWSKMS used for encrypting/decrypting
 // keys with a master key.
+//
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/kms instead.
 func NewAWS(crypto appencryption.AEAD, preferredRegion string, arnMap map[string]string) (*AWSKMS, error) {
 	return newAWS(crypto, preferredRegion, awsARNMap(arnMap))
 }

--- a/go/appencryption/plugins/aws-v1/persistence/dynamodb.go
+++ b/go/appencryption/plugins/aws-v1/persistence/dynamodb.go
@@ -38,6 +38,8 @@ var (
 type ConfigProvider = client.ConfigProvider
 
 // DynamoDBMetastore implements the Metastore interface.
+//
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 type DynamoDBMetastore struct {
 	svc          DynamoDBClientAPI
 	regionSuffix string
@@ -100,6 +102,8 @@ func WithClient(c DynamoDBClientAPI) DynamoDBMetastoreOption {
 }
 
 // NewDynamoDBMetastore creates a new DynamoDBMetastore with the provided session and options.
+//
+// Deprecated: AWS SDK v1 reached end-of-life July 31, 2025. Use github.com/godladdy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore instead.
 func NewDynamoDBMetastore(sess ConfigProvider, opts ...DynamoDBMetastoreOption) *DynamoDBMetastore {
 	d := &DynamoDBMetastore{
 		svc:       dynamodb.New(sess),


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [x] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)

## What's new?
- Add/update deprecation comments for AWS SDK v1 components to reflect the end-of-life status (July 31, 2025) and redirect users to AWS SDK v2 alternatives.
  - pkg/kms and pkg/persistence: Redirect from aws-v1 plugins to aws-v2 plugins
  - plugins/aws-v1: Add deprecation notices to main exported functions and types
  - add linter exclusions for AWS SDK v1 deprecation in backward compatibility layer