### PR TITLE
Fixed disposable issue and added ability to bring your own client

### DIFF
--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/DynamoDbMetastoreImplTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Persistence/DynamoDbMetastoreImplTest.cs
@@ -267,6 +267,23 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Persistence
         }
 
         [Fact]
+        public void TestStoreWithClientProvidedExternally()
+        {
+            var client = new AmazonDynamoDBClient(new AmazonDynamoDBConfig
+            {
+                ServiceURL = serviceUrl,
+                AuthenticationRegion = Region,
+            });
+
+            var dbMetastoreImpl = NewBuilder(Region)
+                .WithDynamoDbClient(client)
+                .Build();
+            bool actualValue = dbMetastoreImpl.Store(TestKey, DateTimeOffset.Now, JObject.FromObject(keyRecord));
+
+            Assert.True(actualValue);
+        }
+
+        [Fact]
         public void TestStoreWithDbErrorShouldThrowException()
         {
             Dispose();

--- a/csharp/AppEncryption/AppEncryption/Persistence/DynamoDbMetastoreImpl.cs
+++ b/csharp/AppEncryption/AppEncryption/Persistence/DynamoDbMetastoreImpl.cs
@@ -43,6 +43,7 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
         private readonly string preferredRegion;
         private readonly Table table;
 
+
         internal DynamoDbMetastoreImpl(Builder builder)
         {
             DbClient = builder.DbClient;
@@ -50,6 +51,7 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
             preferredRegion = builder.PreferredRegion;
             hasKeySuffix = builder.HasKeySuffix;
             this._logger = builder.Logger;
+
 
             // Note this results in a network call. For now, cleaner than refactoring w/ thread-safe lazy loading
             table = builder.LoadTable(DbClient, TableName);
@@ -106,6 +108,15 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
             /// <param name="logger">The logger implementation to use.</param>
             /// <returns>The current <see cref="IBuildStep"/> instance.</returns>
             IBuildStep WithLogger(ILogger logger);
+
+            /// <summary>
+            /// Provides a custom DynamoDB client. When this is used, the credentials, endpoint, and region
+            /// configurations will be ignored.
+            /// </summary>
+            ///
+            /// <param name="client">The custom DynamoDB client to use.</param>
+            /// <returns>The current <see cref="IBuildStep"/> instance.</returns>
+            IBuildStep WithDynamoDbClient(IAmazonDynamoDB client);
 
             /// <summary>
             /// Builds the finalized <see cref="DynamoDbMetastoreImpl"/> with the parameters specified in the builder.
@@ -274,25 +285,30 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
             return DefaultKeySuffix;
         }
 
+
+
         /// <summary>
         /// Builder class to create an instance of the <see cref="DynamoDbMetastoreImpl"/> class.
         /// </summary>
-        public class Builder : IBuildStep, IDisposable
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Builder intentionally does not manage client lifecycle - client cleanup is handled by GC finalizers")]
+        public class Builder : IBuildStep
         {
             private readonly string preferredRegion;
-            private AmazonDynamoDBClient dbClient;
+            private IAmazonDynamoDB dbClient;
             private bool hasKeySuffix;
             private string tableName = DefaultTableName;
             private AWSCredentials credentials;
             private ILogger _logger;
 
+
             // Internal properties for access
             internal string PreferredRegion => preferredRegion;
-            internal AmazonDynamoDBClient DbClient => dbClient;
+            internal IAmazonDynamoDB DbClient => dbClient;
             internal bool HasKeySuffix => hasKeySuffix;
             internal string TableName => tableName;
             internal AWSCredentials Credentials => credentials;
             internal ILogger Logger => _logger;
+
 
             private const string DefaultTableName = "EncryptionKey";
             private readonly AmazonDynamoDBConfig dbConfig = new AmazonDynamoDBConfig();
@@ -367,6 +383,19 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
             }
 
             /// <summary>
+            /// Provides a custom DynamoDB client. When this is used, the credentials, endpoint, and region
+            /// configurations will be ignored.
+            /// </summary>
+            ///
+            /// <param name="client">The custom DynamoDB client to use.</param>
+            /// <returns>The current <see cref="IBuildStep"/> instance.</returns>
+            public IBuildStep WithDynamoDbClient(IAmazonDynamoDB client)
+            {
+                this.dbClient = client;
+                return this;
+            }
+
+            /// <summary>
             /// Builds the finalized <see cref="DynamoDbMetastoreImpl"/> object with the parameters specified in the
             /// <see cref="Builder"/>.
             /// </summary>
@@ -374,12 +403,15 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
             /// <returns>The fully instantiated <see cref="DynamoDbMetastoreImpl"/> object.</returns>
             public DynamoDbMetastoreImpl Build()
             {
-                if (!hasEndPoint && !hasRegion)
+                if (dbClient == null)
                 {
-                    dbConfig.RegionEndpoint = RegionEndpoint.GetBySystemName(preferredRegion);
-                }
+                    if (!hasEndPoint && !hasRegion)
+                    {
+                        dbConfig.RegionEndpoint = RegionEndpoint.GetBySystemName(preferredRegion);
+                    }
 
-                dbClient = new AmazonDynamoDBClient(credentials, dbConfig);
+                    dbClient = new AmazonDynamoDBClient(credentials, dbConfig);
+                }
 
                 return new DynamoDbMetastoreImpl(this);
             }
@@ -392,26 +424,7 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
                     .Build();
             }
 
-            /// <summary>
-            /// Disposes of the managed resources.
-            /// </summary>
-            public void Dispose()
-            {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
 
-            /// <summary>
-            /// Disposes of the managed resources.
-            /// </summary>
-            /// <param name="disposing">True if called from Dispose, false if called from finalizer.</param>
-            protected virtual void Dispose(bool disposing)
-            {
-                if (disposing)
-                {
-                    dbClient?.Dispose();
-                }
-            }
         }
     }
 }

--- a/csharp/AppEncryption/AppEncryption/Persistence/DynamoDbMetastoreImpl.cs
+++ b/csharp/AppEncryption/AppEncryption/Persistence/DynamoDbMetastoreImpl.cs
@@ -85,6 +85,8 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
 
             /// <summary>
             /// Adds Endpoint config to the AWS DynamoDb client.
+            /// Note: This method will be ignored if <see cref="WithRegion"/> has already been called.
+            /// The first method called between <see cref="WithRegion"/> and <see cref="WithEndPointConfiguration"/> takes precedence.
             /// </summary>
             ///
             /// <param name="endPoint">the service endpoint either with or without the protocol.</param>
@@ -95,6 +97,8 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
             /// <summary>
             /// Specifies the region for the AWS DynamoDb client. If this is not specified, then the region from
             /// <see cref="DynamoDbMetastoreImpl.NewBuilder"/> is used.
+            /// Note: This method will be ignored if <see cref="WithEndPointConfiguration"/> has already been called.
+            /// The first method called between <see cref="WithRegion"/> and <see cref="WithEndPointConfiguration"/> takes precedence.
             /// </summary>
             ///
             /// <param name="region">The region for the DynamoDb client.</param>
@@ -112,6 +116,8 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
             /// <summary>
             /// Provides a custom DynamoDB client. When this is used, the credentials, endpoint, and region
             /// configurations will be ignored.
+            /// Note: This method completely bypasses all other client configuration methods.
+            /// This is the recommended approach, especially when using dependency injection frameworks.
             /// </summary>
             ///
             /// <param name="client">The custom DynamoDB client to use.</param>
@@ -385,6 +391,8 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
             /// <summary>
             /// Provides a custom DynamoDB client. When this is used, the credentials, endpoint, and region
             /// configurations will be ignored.
+            /// Note: This method completely bypasses all other client configuration methods.
+            /// This is the recommended approach, especially when using dependency injection frameworks.
             /// </summary>
             ///
             /// <param name="client">The custom DynamoDB client to use.</param>

--- a/csharp/AppEncryption/AppEncryption/Persistence/DynamoDbMetastoreImpl.cs
+++ b/csharp/AppEncryption/AppEncryption/Persistence/DynamoDbMetastoreImpl.cs
@@ -290,7 +290,7 @@ namespace GoDaddy.Asherah.AppEncryption.Persistence
         /// <summary>
         /// Builder class to create an instance of the <see cref="DynamoDbMetastoreImpl"/> class.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Builder intentionally does not manage client lifecycle - client cleanup is handled by GC finalizers")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Builder intentionally should not manage client lifecycle")]
         public class Builder : IBuildStep
         {
             private readonly string preferredRegion;

--- a/csharp/AppEncryption/README.md
+++ b/csharp/AppEncryption/README.md
@@ -95,10 +95,10 @@ build the metastore by calling the `Build` method.
  - **WithKeySuffix**: Specifies whether key suffix should be enabled for DynamoDB. **This is required to enable Global
  Tables**.
  - **WithTableName**: Specifies the name of the DynamoDb table.
- - **WithRegion**: Specifies the region for the AWS DynamoDb client.
- - **WithEndPointConfiguration**: Adds an EndPoint configuration to the AWS DynamoDb client.
+ - **WithRegion**: Specifies the region for the AWS DynamoDb client. *Will be ignored if WithEndPointConfiguration was called first*.
+ - **WithEndPointConfiguration**: Adds an EndPoint configuration to the AWS DynamoDb client. *Will be ignored if WithRegion was called first*.
  - **WithCredentials**: Specifies custom credentials for the AWS DynamoDb client.
- - **WithDynamoDbClient**: **Recommended** - Provides a custom DynamoDB client. This method is preferred over letting the builder create the client, especially when using dependency injection frameworks. It gives you full control over client configuration and lifecycle management.
+ - **WithDynamoDbClient**: **Recommended** - Provides a custom DynamoDB client. This method is preferred over letting the builder create the client, especially when using dependency injection frameworks. It gives you full control over client configuration and lifecycle management. *Completely bypasses all other client configuration methods*.
 
 Below is an example of a DynamoDB metastore that uses a Global Table named `TestTable`
 


### PR DESCRIPTION
To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [x] Tests (if applicable)
* [x] Documentation (if applicable)
* [ ] Changelog entry
* [x] A full explanation here in the PR description of the work done

## PR Type
What kind of change does this PR introduce?

* [x] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [x] Documentation content changes
* [x] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)


## Issue Linking
fixes #1502 

## What's new?
- Fixes an issue with an unneeded and possibly dangerous dispose method in the DynamoDbMetastoreImpl builder that was recently introduced.
- Adds ability to "bring your own IAmazonDynamoDB client" into the Builder that is more friendly with applications using a singleton client in their application and/or dependency injection facades
