### PR TITLE
[go server] Complete AWS KMS plugin upgrade to v2

### DIFF
--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/kms v1.37.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.9 // indirect

--- a/server/go/go.sum
+++ b/server/go/go.sum
@@ -34,6 +34,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.9 h1:raml
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.9/go.mod h1:+B//vxKaB6Z/HfJfRV4ikLz0M7nIcKheHKm96FuaRrs=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.9 h1:TQmKDyETFGiXVhZfQ/I0cCFziqqX58pi4tKJGYGFSz0=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.9/go.mod h1:HVLPK2iHQBUx7HfZeOQSEu3v2ubZaAY2YPbAm5/WUyY=
+github.com/aws/aws-sdk-go-v2/service/kms v1.37.13 h1:JJHYuosiaMHr9V8m+v6UPmM7ZWHP+l8cv/xEG9OQTuE=
+github.com/aws/aws-sdk-go-v2/service/kms v1.37.13/go.mod h1:TTGECZ6vGfx8k/pmzQKokSJy7ux2PJID4r96QCh5L0A=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.11 h1:kuIyu4fTT38Kj7YCC7ouNbVZSSpqkZ+LzIfhCr6Dg+I=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.11/go.mod h1:Ro744S4fKiCCuZECXgOi760TiYylUM8ZBf6OGiZzJtY=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.10 h1:l+dgv/64iVlQ3WsBbnn+JSbkj01jIi+SM0wYsj3y/hY=

--- a/server/go/pkg/server/server.go
+++ b/server/go/pkg/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/godaddy/asherah/go/appencryption/pkg/kms"
 	"github.com/godaddy/asherah/go/appencryption/pkg/persistence"
 	"github.com/godaddy/asherah/go/appencryption/plugins/aws-v2/dynamodb/metastore"
+	awsv2kms "github.com/godaddy/asherah/go/appencryption/plugins/aws-v2/kms"
 	"github.com/godaddy/asherah/go/securememory/memguard"
 
 	pb "github.com/godaddy/asherah/server/go/api"
@@ -148,7 +149,7 @@ func NewKMS(opts *Options, crypto appencryption.AEAD) appencryption.KeyManagemen
 		return m
 	}
 
-	m, err := kms.NewAWS(crypto, opts.PreferredRegion, opts.RegionMap)
+	m, err := awsv2kms.NewAWS(crypto, opts.PreferredRegion, opts.RegionMap)
 	if err != nil {
 		panic(err)
 	}

--- a/server/go/pkg/server/server_test.go
+++ b/server/go/pkg/server/server_test.go
@@ -343,13 +343,16 @@ func Test_Streamer_StreamGetSession(t *testing.T) {
 func Test_NewAppEncryption(t *testing.T) {
 	// A simple smoke test that consturcts new handlers
 	// using a variety of configuration options.
+	testRegionMap := make(RegionMap)
+	testRegionMap["us-west-2"] = "arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012"
+
 	optCombos := []*Options{
-		{KMS: "aws", Metastore: "rdbms"},
-		{KMS: "aws", Metastore: "rdbms", ReplicaReadConsistency: "session"},
-		{KMS: "aws", Metastore: "dynamodb"},
-		{KMS: "aws", Metastore: "dynamodb", DynamoDBRegion: "us-east-1"},
-		{KMS: "aws", Metastore: "dynamodb", DynamoDBEndpoint: "http://localhost:8000"},
-		{KMS: "aws", Metastore: "dynamodb", DynamoDBTableName: "CustomTableName"},
+		{KMS: "aws", Metastore: "rdbms", PreferredRegion: "us-west-2", RegionMap: testRegionMap},
+		{KMS: "aws", Metastore: "rdbms", ReplicaReadConsistency: "session", PreferredRegion: "us-west-2", RegionMap: testRegionMap},
+		{KMS: "aws", Metastore: "dynamodb", PreferredRegion: "us-west-2", RegionMap: testRegionMap},
+		{KMS: "aws", Metastore: "dynamodb", DynamoDBRegion: "us-east-1", PreferredRegion: "us-west-2", RegionMap: testRegionMap},
+		{KMS: "aws", Metastore: "dynamodb", DynamoDBEndpoint: "http://localhost:8000", PreferredRegion: "us-west-2", RegionMap: testRegionMap},
+		{KMS: "aws", Metastore: "dynamodb", DynamoDBTableName: "CustomTableName", PreferredRegion: "us-west-2", RegionMap: testRegionMap},
 		{KMS: "static", Metastore: "rdbms"},
 		{KMS: "static", Metastore: "memory"},
 	}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [x] Tests
* [x] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [x] Yes (backward compatible)
* [ ] No (breaking changes)

## What's new?
Updates server to use aws-v2/kms plugin instead of deprecated kms.NewAWS. Fixes CI failure caused by incomplete migration from AWS SDK v1 to v2.

- Import aws-v2/kms plugin and use awsv2kms.NewAWS()
- Update test cases to provide required RegionMap for AWS KMS
- Add missing aws-sdk-go-v2/service/kms dependency
