### PR TITLE
[csharp appencryption] Fix cross-region IK cache pollution in multi-region setups

### DIFF
--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Envelope/EnvelopeEncryptionJsonImplTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Envelope/EnvelopeEncryptionJsonImplTest.cs
@@ -346,8 +346,9 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Envelope
         [Fact]
         private void TestWithIntermediateKeyForReadWithKeyNotCachedAndCanCacheAndNotExpiredShouldLookupAndCache()
         {
-            keyMetaMock.Setup(x => x.Created).Returns(ikDateTime);
-            envelopeEncryptionJsonImplSpy.Setup(x => x.GetIntermediateKey(keyMetaMock.Object))
+            var ikKeyMeta = new Mock<KeyMeta>(partition.IntermediateKeyId, DateTimeOffset.UtcNow);
+            ikKeyMeta.Setup(x => x.Created).Returns(ikDateTime);
+            envelopeEncryptionJsonImplSpy.Setup(x => x.GetIntermediateKey(ikKeyMeta.Object))
                 .Returns(intermediateCryptoKeyMock.Object);
             cryptoPolicyMock.Setup(x => x.CanCacheIntermediateKeys()).Returns(true);
             intermediateCryptoKeyMock.Setup(x => x.GetCreated()).Returns(ikDateTime);
@@ -359,9 +360,9 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Envelope
             Func<CryptoKey, byte[]> functionWithIntermediateKey = cryptoKey => expectedBytes;
 
             byte[] actualBytes = envelopeEncryptionJsonImplSpy.Object.WithIntermediateKeyForRead(
-                keyMetaMock.Object, functionWithIntermediateKey);
+                ikKeyMeta.Object, functionWithIntermediateKey);
             Assert.Equal(expectedBytes, actualBytes);
-            envelopeEncryptionJsonImplSpy.Verify(x => x.GetIntermediateKey(keyMetaMock.Object));
+            envelopeEncryptionJsonImplSpy.Verify(x => x.GetIntermediateKey(ikKeyMeta.Object));
             intermediateKeyCacheMock.Verify(x => x.PutAndGetUsable(intermediateCryptoKeyMock.Object.GetCreated(), intermediateCryptoKeyMock.Object));
             intermediateCryptoKeyMock.Verify(x => x.Dispose());
         }
@@ -369,7 +370,8 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Envelope
         [Fact]
         private void TestWithIntermediateKeyForReadWithKeyNotCachedAndCanCacheAndCacheUpdateFailsShouldLookupAndFailAndDisposeKey()
         {
-            keyMetaMock.Setup(x => x.Created).Returns(ikDateTime);
+            var ikKeyMeta = new Mock<KeyMeta>(partition.IntermediateKeyId, DateTimeOffset.UtcNow);
+            ikKeyMeta.Setup(x => x.Created).Returns(ikDateTime);
             envelopeEncryptionJsonImplSpy.Setup(x => x.GetIntermediateKey(It.IsAny<KeyMeta>()))
                 .Returns(intermediateCryptoKeyMock.Object);
             cryptoPolicyMock.Setup(x => x.CanCacheIntermediateKeys()).Returns(true);
@@ -380,8 +382,8 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Envelope
             Func<CryptoKey, byte[]> functionWithIntermediateKey = cryptoKey => expectedBytes;
 
             Assert.Throws<AppEncryptionException>(() => envelopeEncryptionJsonImplSpy.Object.WithIntermediateKeyForRead(
-                keyMetaMock.Object, functionWithIntermediateKey));
-            envelopeEncryptionJsonImplSpy.Verify(x => x.GetIntermediateKey(keyMetaMock.Object));
+                ikKeyMeta.Object, functionWithIntermediateKey));
+            envelopeEncryptionJsonImplSpy.Verify(x => x.GetIntermediateKey(ikKeyMeta.Object));
             intermediateCryptoKeyMock.Verify(x => x.Dispose());
         }
 
@@ -573,27 +575,29 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Envelope
         [Fact]
         private void TestWithExistingSystemKeyWithKeyNotCachedAndCanCacheAndNotExpiredShouldLookupAndCache()
         {
+            var skKeyMeta = new Mock<KeyMeta>(partition.SystemKeyId, DateTimeOffset.UtcNow);
             envelopeEncryptionJsonImplSpy.Setup(x => x.GetSystemKey(It.IsAny<KeyMeta>()))
                 .Returns(systemCryptoKeyMock.Object);
             cryptoPolicyMock.Setup(x => x.CanCacheSystemKeys()).Returns(true);
-            keyMetaMock.Setup(x => x.Created).Returns(skDateTime);
-            systemKeyCacheMock.Setup(x => x.PutAndGetUsable(keyMetaMock.Object.Created, systemCryptoKeyMock.Object))
+            skKeyMeta.Setup(x => x.Created).Returns(skDateTime);
+            systemKeyCacheMock.Setup(x => x.PutAndGetUsable(skKeyMeta.Object.Created, systemCryptoKeyMock.Object))
                 .Returns(systemCryptoKeyMock.Object);
 
             byte[] expectedBytes = { 0, 1, 2, 3 };
             Func<CryptoKey, byte[]> functionWithSystemKey = cryptoKey => expectedBytes;
 
             byte[] actualBytes =
-                envelopeEncryptionJsonImplSpy.Object.WithExistingSystemKey(keyMetaMock.Object, false, functionWithSystemKey);
+                envelopeEncryptionJsonImplSpy.Object.WithExistingSystemKey(skKeyMeta.Object, false, functionWithSystemKey);
             Assert.Equal(expectedBytes, actualBytes);
-            envelopeEncryptionJsonImplSpy.Verify(x => x.GetSystemKey(keyMetaMock.Object));
-            systemKeyCacheMock.Verify(x => x.PutAndGetUsable(keyMetaMock.Object.Created, systemCryptoKeyMock.Object));
+            envelopeEncryptionJsonImplSpy.Verify(x => x.GetSystemKey(skKeyMeta.Object));
+            systemKeyCacheMock.Verify(x => x.PutAndGetUsable(skKeyMeta.Object.Created, systemCryptoKeyMock.Object));
             systemCryptoKeyMock.Verify(x => x.Dispose());
         }
 
         [Fact]
         private void TestWithExistingSystemKeyWithKeyNotCachedAndCanCacheAndCacheUpdateFailsShouldLookupAndFailAndDisposeKey()
         {
+            var skKeyMeta = new Mock<KeyMeta>(partition.SystemKeyId, DateTimeOffset.UtcNow);
             envelopeEncryptionJsonImplSpy.Setup(x => x.GetSystemKey(It.IsAny<KeyMeta>()))
                 .Returns(systemCryptoKeyMock.Object);
             cryptoPolicyMock.Setup(x => x.CanCacheSystemKeys()).Returns(true);
@@ -604,8 +608,8 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Envelope
             Func<CryptoKey, byte[]> functionWithSystemKey = cryptoKey => expectedBytes;
 
             Assert.Throws<AppEncryptionException>(() =>
-                envelopeEncryptionJsonImplSpy.Object.WithExistingSystemKey(keyMetaMock.Object, false, functionWithSystemKey));
-            envelopeEncryptionJsonImplSpy.Verify(x => x.GetSystemKey(keyMetaMock.Object));
+                envelopeEncryptionJsonImplSpy.Object.WithExistingSystemKey(skKeyMeta.Object, false, functionWithSystemKey));
+            envelopeEncryptionJsonImplSpy.Verify(x => x.GetSystemKey(skKeyMeta.Object));
             systemCryptoKeyMock.Verify(x => x.Dispose());
         }
 

--- a/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Envelope/EnvelopeEncryptionJsonImplTest.cs
+++ b/csharp/AppEncryption/AppEncryption.Tests/AppEncryption/Envelope/EnvelopeEncryptionJsonImplTest.cs
@@ -1555,5 +1555,63 @@ namespace GoDaddy.Asherah.AppEncryption.Tests.AppEncryption.Envelope
         {
             Assert.False(envelopeEncryptionJsonImplSpy.Object.IsKeyExpiredOrRevoked(systemCryptoKeyMock.Object));
         }
+
+        [Fact]
+        private void TestWritePathShouldNotUseCrossRegionIntermediateKeyFromReadCache()
+        {
+            // Use SuffixedPartition (not the default partition) and a REAL intermediate key cache
+            var suffixedPartition = new SuffixedPartition(
+                "order-processing", "order-processing-service", "ecomm", "us-west-2");
+            var realIkCache = new SecureCryptoKeyDictionary<DateTimeOffset>(long.MaxValue);
+
+            var impl = new Mock<EnvelopeEncryptionJsonImpl>(
+                suffixedPartition,
+                metastoreMock.Object,
+                systemKeyCacheMock.Object,
+                realIkCache,
+                aeadEnvelopeCryptoMock.Object,
+                cryptoPolicyMock.Object,
+                keyManagementServiceMock.Object,
+                mockLogger.Object)
+            { CallBase = true };
+
+            // Two IKs: local (earlier) and cross-region (later)
+            DateTimeOffset localCreated = DateTimeOffset.UtcNow.Truncate(TimeSpan.FromSeconds(1)).AddHours(-1);
+            DateTimeOffset crossRegionCreated = localCreated.AddMinutes(30);
+
+            var localIK = new Mock<CryptoKey>();
+            localIK.Setup(x => x.GetCreated()).Returns(localCreated);
+
+            var crossRegionIK = new Mock<CryptoKey>();
+            crossRegionIK.Setup(x => x.GetCreated()).Returns(crossRegionCreated);
+
+            // Pre-populate cache with local IK (simulating a prior local write)
+            realIkCache.PutAndGetUsable(localCreated, localIK.Object);
+
+            // Enable IK caching
+            cryptoPolicyMock.Setup(x => x.CanCacheIntermediateKeys()).Returns(true);
+
+            // Stub GetIntermediateKey to return the cross-region IK when reading cross-region data
+            var crossRegionMeta = new KeyMeta(
+                "_IK_order-processing_order-processing-service_ecomm_us-east-1", crossRegionCreated);
+            impl.Setup(x => x.GetIntermediateKey(crossRegionMeta))
+                .Returns(crossRegionIK.Object);
+
+            // Read path: decrypt data originally encrypted in us-east-1 -> cross-region IK enters cache
+            impl.Object.WithIntermediateKeyForRead(crossRegionMeta, key => "ok");
+
+            // Write path: GetLast() should return the LOCAL key, not the cross-region key
+            DateTimeOffset usedKeyCreated = DateTimeOffset.MinValue;
+            impl.Object.WithIntermediateKeyForWrite(key =>
+            {
+                usedKeyCreated = key.GetCreated();
+                return "ok";
+            });
+
+            // Assert: the write used the local key, not the cross-region key
+            Assert.Equal(
+                localCreated,
+                usedKeyCreated);
+        }
     }
 }

--- a/csharp/AppEncryption/AppEncryption/Envelope/EnvelopeEncryptionJsonImpl.cs
+++ b/csharp/AppEncryption/AppEncryption/Envelope/EnvelopeEncryptionJsonImpl.cs
@@ -215,8 +215,11 @@ namespace GoDaddy.Asherah.AppEncryption.Envelope
             {
                 intermediateKey = GetIntermediateKey(intermediateKeyMeta);
 
-                // Put the key into our cache if allowed
-                if (cryptoPolicy.CanCacheIntermediateKeys())
+                // Only cache if the key belongs to this partition's region to prevent cross-region
+                // cache pollution that could cause WithIntermediateKeyForWrite's GetLast() to return
+                // a key from a different region
+                if (cryptoPolicy.CanCacheIntermediateKeys()
+                    && partition.IntermediateKeyId.Equals(intermediateKeyMeta.KeyId, StringComparison.Ordinal))
                 {
                     try
                     {
@@ -298,8 +301,11 @@ namespace GoDaddy.Asherah.AppEncryption.Envelope
             {
                 systemKey = GetSystemKey(systemKeyMeta);
 
-                // Put the key into our cache if allowed
-                if (cryptoPolicy.CanCacheSystemKeys())
+                // Only cache if the key belongs to this partition's region to prevent cross-region
+                // cache pollution that could cause WithSystemKeyForWrite's GetLast() to return
+                // a key from a different region
+                if (cryptoPolicy.CanCacheSystemKeys()
+                    && partition.SystemKeyId.Equals(systemKeyMeta.KeyId, StringComparison.Ordinal))
                 {
                     try
                     {

--- a/csharp/AppEncryption/Directory.Build.props
+++ b/csharp/AppEncryption/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- **Bug fix**: Port of the Java fix (PR #1696) to C#. In multi-region setups using `WithKeySuffix`, the read path (`WithIntermediateKeyForRead`) cached cross-region intermediate keys by `DateTimeOffset` timestamp only. The write path's `GetLast()` could then return a cross-region key with a later timestamp, causing `EncryptPayload` to write a mismatched `KeyMeta` (local region keyId + cross-region created timestamp). This KeyMeta has no corresponding record in the metastore, so subsequent decryption fails with `MetadataMissingException`.
- **Fix**: Only cache keys in the read path when their `KeyId` matches the local partition's key ID. Same fix applied to the system key path (`WithExistingSystemKey`). Cross-region reads still work — keys are fetched from the metastore, just not cached.
- **Version bump**: C# AppEncryption bumpted to 0.11.0.
- **Note**: The Go SDK is not affected — its cache is keyed by composite `(keyId, timestamp)` with region-aware latest tracking.

## Test plan
- [x] Regression test added (`TestWritePathShouldNotUseCrossRegionIntermediateKeyFromReadCache`) — uses a real `SecureCryptoKeyDictionary` with a `SuffixedPartition` to prove the cache pollution scenario
- [x] Verified test fails before fix (write path returns cross-region key's timestamp)
- [x] Verified test passes after fix
- [x] Full test suite passes (354 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)