### PR TITLE
Bump golangci-lint to v2.13.1 for Go 1.27 support

### DIFF
--- a/.github/workflows/cross-language-validation.yml
+++ b/.github/workflows/cross-language-validation.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Lint the Go project
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: 'v2.9.0'
+          version: 'v2.13.1'
           skip-cache: true
           working-directory: 'tests/cross-language/go'
 

--- a/.github/workflows/go-appencryption-ci.yml
+++ b/.github/workflows/go-appencryption-ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: 'v2.9.0'
+          version: 'v2.13.1'
           skip-cache: true
           working-directory: 'go/appencryption'
 

--- a/.github/workflows/go-pr.yml
+++ b/.github/workflows/go-pr.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: 'v2.9.0'
+          version: 'v2.13.1'
           skip-cache: true
           working-directory: 'samples/go/referenceapp'
 
@@ -125,6 +125,6 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: 'v2.9.0'
+          version: 'v2.13.1'
           skip-cache: true
           working-directory: 'server/go'

--- a/.github/workflows/go-securememory-ci.yml
+++ b/.github/workflows/go-securememory-ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Run linters
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: 'v2.9.0'
+          version: 'v2.13.1'
           skip-cache: true
           working-directory: 'go/securememory'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,9 @@ Asherah is an application-layer encryption SDK providing envelope encryption wit
 
 ## Lint Commands
 - C#: `dotnet format` for formatting, built-in analyzers
-- Go: Binary installation via `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.9.0`
+- Go: Binary installation via `curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.13.1`
   - Alternatively: `brew install golangci-lint` (installs latest v2)
-  - Version should match CI configuration (currently v2.9.0)
+  - Version should match CI configuration (currently v2.13.1)
   - Run with: `golangci-lint run` in module directory
 - Java: Checkstyle via Maven (configured in pom.xml)
 

--- a/go/appencryption/.golangci.yml
+++ b/go/appencryption/.golangci.yml
@@ -32,7 +32,7 @@ linters:
     - gocyclo
     - godot
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - gosec
     - gosmopolitan
     - loggercheck

--- a/go/appencryption/pkg/cache/internal/hash.go
+++ b/go/appencryption/pkg/cache/internal/hash.go
@@ -124,7 +124,7 @@ func hashPointer(k interface{}) (uint64, bool) {
 
 	//nolint:exhaustive
 	switch v.Kind() {
-	case reflect.Ptr, reflect.UnsafePointer, reflect.Func, reflect.Slice, reflect.Map, reflect.Chan:
+	case reflect.Pointer, reflect.UnsafePointer, reflect.Func, reflect.Slice, reflect.Map, reflect.Chan:
 		return hashU64(uint64(v.Pointer())), true
 	default:
 		return 0, false


### PR DESCRIPTION
* [ ] Tests (if applicable) — no new tests; existing Go suites cover this
* [x] Documentation (if applicable) — `CLAUDE.md` lint instructions updated
* [ ] Changelog entry — n/a, repo has no changelog
* [x] A full explanation here in the PR description of the work done

## PR Type

* [x] CI related changes

## Backward Compatibility

* [x] Yes (backward compatible)

No API or runtime behavior change. `reflect.Ptr` and `reflect.Pointer` are the same
constant (both `22`).

## What's new?

`actions/setup-go` resolves `go-version: stable` to Go 1.27.0. golangci-lint v2.9.0 is
built with Go 1.26.0 and cannot decode Go 1.27 export data, so every Go lint step now
fails during typecheck:

```
could not import internal/cpu (-: could not load export data: cannot decode
"internal/cpu", export data version 4 is greater than maximum supported version 2)
```

- Raise golangci-lint v2.9.0 → v2.13.1 across all five workflow pins. v2.13.0 is the
  first release built with Go 1.27.0.
- `reflect.Ptr` → `reflect.Pointer` in `pkg/cache/internal/hash.go`; govet's `inline`
  check flags the legacy alias.
- `gomodguard` → `gomodguard_v2` in `go/appencryption/.golangci.yml`; deprecated since
  v2.12.0 and warned on every run. No `gomodguard` settings block exists, so there is no
  settings migration.
- `CLAUDE.md` install command now uses `https://golangci-lint.run/install.sh`. The
  previously documented `master`-branch script verifies checksums with an unanchored
  `grep`, and since v2.12.0 the checksums file also lists `<asset>.tar.gz.sbom.json`, so
  verification always failed and nothing installed.

Verified locally with v2.13.1 against all five lint targets (`go/appencryption`,
`go/securememory`, `server/go`, `samples/go/referenceapp`, `tests/cross-language/go`):
0 issues, no deprecation warnings, and `config verify` passes. The `go/appencryption`
unit suite passes. `go build`, `go vet -stdversion`, and `go test -race` were also run
under a real Go 1.27.0 toolchain, since CI has not yet executed tests under 1.27 — the
lint step fails ahead of them in the same job.

`go-version: stable` is deliberately left unpinned, so a future Go minor release can
break linting again until the pin is raised.
